### PR TITLE
fix(security): remove duplicate /index.html in setRedirectUrls (feature/vuejs only)

### DIFF
--- a/app-ui/src/main/java/org/ligoj/boot/web/SecurityConfiguration.java
+++ b/app-ui/src/main/java/org/ligoj/boot/web/SecurityConfiguration.java
@@ -108,7 +108,7 @@ public class SecurityConfiguration {
 	@Bean
 	public RedirectAuthenticationEntryPoint ajaxFormLoginEntryPoint(AbstractAuthenticationProvider provider) {
 		final var ep = new RedirectAuthenticationEntryPoint(loginUrl);
-		ep.setRedirectUrls(Set.of("/", "", INDEX_HTML, "/index.html", "/login.html"));
+        ep.setRedirectUrls(Set.of("/", "", INDEX_HTML, "/login.html"));
 		ep.setRedirectStrategy(getRestFailureStrategy());
 		ep.setForceRedirectUrl(provider.isForceRedirect());
 		return ep;


### PR DESCRIPTION
On `feature/vuejs`, `Set.of("/", "", INDEX_HTML, "/index.html", "/login.html")`
throws `IllegalArgumentException` au démarrage car `INDEX_HTML = "/index.html"` →
doublon dans `Set.of`. Bloque tout login.

**Note pour Fabrice :** ce bug est déjà corrigé sur `master` (ligne réécrite avec
`/index-prod.html`, `/v-index.html`, etc.). Le fix proposé ici est un correctif
local minimal pour `feature/vuejs`. Si tu préfères merger `master` →
`feature/vuejs` plus tard, on peut fermer cette PR sans merger — à toi de voir.

Trace : `BeanInstantiationException on ajaxFormLoginEntryPoint -> duplicate element`.