### PR TITLE
fix(webapp): use relative paths for entry script tags

### DIFF
--- a/app-ui/src/main/webapp/index.html
+++ b/app-ui/src/main/webapp/index.html
@@ -82,7 +82,7 @@
 			<p class="ligoj-boot__text">Loading…</p>
 		</div>
 	</div>
-	<script type="module" src="/src/main.js"></script>
+	<script type="module" src="./src/main.js"></script>
 </body>
 
 </html>

--- a/app-ui/src/main/webapp/login.html
+++ b/app-ui/src/main/webapp/login.html
@@ -11,7 +11,7 @@
 
 <body>
 	<div id="app"></div>
-	<script type="module" src="/src/login.js"></script>
+	<script type="module" src="./src/login.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
Vite v8 ne préfixe pas toujours `base: '/ligoj/'` aux paths absolus
(`/src/main.js`, `/src/login.js`) dans les entry HTML.

Symptôme reproduit : après logout ou session expirée sur `login.html`, le
navigateur charge `/src/login.js` → 404. Passer en `./src/login.js` (relatif au
document) marche en dev (Vite) et en prod (Spring static).

Affecte : `index.html:85`, `login.html:14`.