### PR TITLE
feat(ui): uniform Admin cards on Dashboard

### DIFF
--- a/app-ui/src/main/webapp/src/i18n/en.js
+++ b/app-ui/src/main/webapp/src/i18n/en.js
@@ -70,6 +70,14 @@ export default {
   'dashboard.manageContainerScopes': 'Manage container scopes',
   'dashboard.manageProjects': 'Manage projects and subscriptions',
   'dashboard.manageAdmin': 'System administration',
+  'dashboard.manageInformation': 'View system status',
+  'dashboard.manageConfiguration': 'Manage system configuration',
+  'dashboard.manageSystemUsers': 'Manage system accounts',
+  'dashboard.manageRoles': 'Manage roles and permissions',
+  'dashboard.managePlugins': 'Manage installed plugins',
+  'dashboard.manageNodes': 'Manage nodes and IAM providers',
+  'dashboard.manageCache': 'Manage application cache',
+  'dashboard.manageBench': 'Test database performance',
 
   // Subscriptions
   'subscription.title': 'Subscriptions',

--- a/app-ui/src/main/webapp/src/i18n/fr.js
+++ b/app-ui/src/main/webapp/src/i18n/fr.js
@@ -70,6 +70,14 @@ export default {
   'dashboard.manageContainerScopes': 'Gérer les portées de conteneurs',
   'dashboard.manageProjects': 'Gérer les projets et souscriptions',
   'dashboard.manageAdmin': 'Administration système',
+  'dashboard.manageInformation': 'Voir l\'état du système',
+  'dashboard.manageConfiguration': 'Gérer la configuration système',
+  'dashboard.manageSystemUsers': 'Gérer les comptes système',
+  'dashboard.manageRoles': 'Gérer les rôles et permissions',
+  'dashboard.managePlugins': 'Gérer les plugins installés',
+  'dashboard.manageNodes': 'Gérer les nœuds et fournisseurs IAM',
+  'dashboard.manageCache': 'Gérer le cache applicatif',
+  'dashboard.manageBench': 'Tester les performances de la base',
 
   // Subscriptions
   'subscription.title': 'Souscriptions',

--- a/app-ui/src/main/webapp/src/views/HomeView.vue
+++ b/app-ui/src/main/webapp/src/views/HomeView.vue
@@ -35,13 +35,24 @@ const i18n = useI18nStore()
 const t = i18n.t
 
 const CARD_META = computed(() => ({
+  // Identity
   'id-user': { color: 'blue', subtitle: t('dashboard.manageUsers') },
   'id-group': { color: 'teal', subtitle: t('dashboard.manageGroups') },
   'id-company': { color: 'indigo', subtitle: t('dashboard.manageCompanies') },
   'id-delegate': { color: 'purple', subtitle: t('dashboard.manageDelegates') },
   'id-container-scope': { color: 'cyan', subtitle: t('dashboard.manageContainerScopes') },
+  // Projects
   'project': { color: 'orange', subtitle: t('dashboard.manageProjects') },
+  // Administration — uniform slate color signals the "admin" section
   'admin': { color: 'red', subtitle: t('dashboard.manageAdmin') },
+  'system-information': { color: 'blue-grey-darken-1', subtitle: t('dashboard.manageInformation') },
+  'system-configuration': { color: 'blue-grey-darken-1', subtitle: t('dashboard.manageConfiguration') },
+  'system-user': { color: 'blue-grey-darken-1', subtitle: t('dashboard.manageSystemUsers') },
+  'system-role': { color: 'blue-grey-darken-1', subtitle: t('dashboard.manageRoles') },
+  'system-plugin': { color: 'blue-grey-darken-1', subtitle: t('dashboard.managePlugins') },
+  'system-node': { color: 'blue-grey-darken-1', subtitle: t('dashboard.manageNodes') },
+  'system-cache': { color: 'blue-grey-darken-1', subtitle: t('dashboard.manageCache') },
+  'system-bench': { color: 'blue-grey-darken-1', subtitle: t('dashboard.manageBench') },
 }))
 
 /** Flatten nav items into dashboard cards */


### PR DESCRIPTION
Harmonise les 8 sous-cards `system-*` (Information, Configuration, Users, Roles,
Plugins, Nodes, Cache, Bench) avec le reste du dashboard :
- avatar blue-grey-darken-1 (visuellement signale la section admin)
- sous-titre descriptif (clés `dashboard.manage*` en fr/en)

Effet de bord positif : les icônes admin étaient invisibles en light mode
(icône blanche sur fond transparent). Avec un avatar coloré, elles sont
visibles dans les deux thèmes.

Fichiers : `HomeView.vue`, `i18n/fr.js`, `i18n/en.js` (+8 clés chacun).