### PR TITLE
fix(ui): consistent DataTable column alignment

### DIFF
--- a/app-ui/src/main/webapp/src/components/LigojDataTable.vue
+++ b/app-ui/src/main/webapp/src/components/LigojDataTable.vue
@@ -145,4 +145,15 @@ defineExpose({ exportCsv, copyToClipboard })
 .ligoj-data-table :deep(tr td:last-child) {
   text-align: end;
 }
+/* Vuetify 4 only styles the header for align=*, not the body cells.
+   Propagate alignment to body cells so columns visually match their header. */
+:deep(tbody > tr > td.v-data-table-column--align-end) {
+  text-align: end;
+}
+:deep(tbody > tr > td.v-data-table-column--align-center) {
+  text-align: center;
+}
+:deep(tbody > tr > td.v-data-table-column--align-start) {
+  text-align: start;
+}
 </style>

--- a/app-ui/src/main/webapp/src/components/LigojDataTable.vue
+++ b/app-ui/src/main/webapp/src/components/LigojDataTable.vue
@@ -1,7 +1,7 @@
 <template>
   <v-data-table
     v-bind="$attrs"
-    :headers="headers"
+    :headers="normalizedHeaders"
     :items="items"
     class="ligoj-data-table"
   >
@@ -76,6 +76,20 @@ const lastKey = computed(() => {
   return last?.key ?? last?.value ?? null
 })
 
+/**
+ * Force `align: 'end'` on the last column so body cells align with the
+ * TableToolsMenu cog placed in this column's header (issue #41). The
+ * consumer's own `align` on the last column is intentionally overridden
+ * — the goal is layout consistency across every DataTable in the app.
+ */
+const normalizedHeaders = computed(() => {
+  if (!props.headers.length) return props.headers
+  const list = [...props.headers]
+  const lastIdx = list.length - 1
+  list[lastIdx] = { ...list[lastIdx], align: 'end' }
+  return list
+})
+
 const toolsSlotName = computed(() => (lastKey.value ? `header.${lastKey.value}` : ''))
 
 const customLastHeaderSlot = computed(() =>
@@ -124,5 +138,11 @@ defineExpose({ exportCsv, copyToClipboard })
 .ligoj-th-sortable {
   cursor: pointer;
   user-select: none;
+}
+/* Issue #41 safety net: Vuetify 4 doesn't always propagate header.align
+ * to slot content rendered inside cells, so we explicitly right-align
+ * the last column body cells to match the header tools menu. */
+.ligoj-data-table :deep(tr td:last-child) {
+  text-align: end;
 }
 </style>

--- a/app-ui/src/main/webapp/src/components/LigojDataTableServer.vue
+++ b/app-ui/src/main/webapp/src/components/LigojDataTableServer.vue
@@ -168,4 +168,15 @@ defineExpose({ exportCsv, copyToClipboard })
 .ligoj-data-table-server :deep(tr td:last-child) {
   text-align: end;
 }
+/* Vuetify 4 only styles the header for align=*, not the body cells.
+   Propagate alignment to body cells so columns visually match their header. */
+:deep(tbody > tr > td.v-data-table-column--align-end) {
+  text-align: end;
+}
+:deep(tbody > tr > td.v-data-table-column--align-center) {
+  text-align: center;
+}
+:deep(tbody > tr > td.v-data-table-column--align-start) {
+  text-align: start;
+}
 </style>

--- a/app-ui/src/main/webapp/src/components/LigojDataTableServer.vue
+++ b/app-ui/src/main/webapp/src/components/LigojDataTableServer.vue
@@ -1,7 +1,7 @@
 <template>
   <v-data-table-server
     v-bind="$attrs"
-    :headers="headers"
+    :headers="normalizedHeaders"
     :items="items"
     :items-length="itemsLength"
     :loading="loading"
@@ -99,6 +99,20 @@ const lastKey = computed(() => {
   return last?.key ?? last?.value ?? null
 })
 
+/**
+ * Force `align: 'end'` on the last column so body cells align with the
+ * TableToolsMenu cog placed in this column's header (issue #41). The
+ * consumer's own `align` on the last column is intentionally overridden
+ * — the goal is layout consistency across every DataTable in the app.
+ */
+const normalizedHeaders = computed(() => {
+  if (!props.headers.length) return props.headers
+  const list = [...props.headers]
+  const lastIdx = list.length - 1
+  list[lastIdx] = { ...list[lastIdx], align: 'end' }
+  return list
+})
+
 const toolsSlotName = computed(() => (lastKey.value ? `header.${lastKey.value}` : ''))
 
 const customLastHeaderSlot = computed(() =>
@@ -147,5 +161,11 @@ defineExpose({ exportCsv, copyToClipboard })
 .ligoj-th-sortable {
   cursor: pointer;
   user-select: none;
+}
+/* Issue #41 safety net: Vuetify 4 doesn't always propagate header.align
+ * to slot content rendered inside cells, so we explicitly right-align
+ * the last column body cells to match the header tools menu. */
+.ligoj-data-table-server :deep(tr td:last-child) {
+  text-align: end;
 }
 </style>

--- a/app-ui/src/main/webapp/src/components/TableToolsMenu.vue
+++ b/app-ui/src/main/webapp/src/components/TableToolsMenu.vue
@@ -6,7 +6,7 @@
         <v-btn
           v-bind="activatorProps"
           icon
-          size="x-small"
+          size="small"
           variant="text"
           aria-label="Table tools"
           title="Table tools"


### PR DESCRIPTION
## Context

Vuetify 4 sets `v-data-table-column--align-{start|center|end}` classes on `<td>` elements but only styles the header content for them, leaving body cells with the default `text-align: start`. The tools column also looked inconsistent: gear right-aligned in header, actions left-aligned in rows.

## Fix

- Scoped CSS rules on both LigojDataTable wrappers that apply `text-align` based on the Vuetify class already present on `<td>`.
- Default the last column to `align: 'end'` via a computed `normalizedHeaders` so the tools column is right-aligned without per-table config.
- Bumps TableToolsMenu icon size from x-small to small for consistency with row action buttons.

## Test plan

- npm run build : OK
- npx vitest run : OK
- Smoke test on Identité → Délégués / Utilisateurs / Entités / Groupes : tools column right-aligned, Admin/Write checks centered, no other visual regression.

Closes ligoj/plugin-id#41