### PR TITLE
feat(ui): user setting to skip unsaved-changes confirmation

### DIFF
--- a/app-ui/src/main/webapp/src/components/LigojConfirmDialog.vue
+++ b/app-ui/src/main/webapp/src/components/LigojConfirmDialog.vue
@@ -10,6 +10,15 @@
       <v-card-text>
         <slot>{{ message }}</slot>
       </v-card-text>
+      <v-card-text v-if="showSkipForeverCheckbox" class="pt-0">
+        <v-checkbox
+          :model-value="skipForever"
+          @update:model-value="$emit('update:skipForever', $event)"
+          :label="t('common.dontAskAgain')"
+          hide-details
+          density="compact"
+        />
+      </v-card-text>
       <v-card-actions>
         <v-spacer />
         <v-btn variant="text" :disabled="loading" @click="onCancel">
@@ -74,9 +83,12 @@ const props = defineProps({
   loading: { type: Boolean, default: false },
   maxWidth: { type: [Number, String], default: 400 },
   persistent: { type: Boolean, default: false },
+  /** Optionally render a "don't ask again" checkbox above the actions. */
+  showSkipForeverCheckbox: { type: Boolean, default: false },
+  skipForever: { type: Boolean, default: false },
 })
 
-const emit = defineEmits(['update:modelValue', 'confirm', 'cancel'])
+const emit = defineEmits(['update:modelValue', 'confirm', 'cancel', 'update:skipForever'])
 const { t } = useI18nStore()
 
 const resolvedCancelLabel = computed(() => props.cancelLabel || t('common.cancel'))

--- a/app-ui/src/main/webapp/src/composables/useFormGuard.js
+++ b/app-ui/src/main/webapp/src/composables/useFormGuard.js
@@ -1,10 +1,15 @@
 import { ref, watch, onBeforeUnmount } from 'vue'
 import { onBeforeRouteLeave, useRouter } from 'vue-router'
 
+const STORAGE_KEY = 'ligoj.skipUnsavedConfirmation'
+
 export function useFormGuard(formData) {
   const router = useRouter()
   const isDirty = ref(false)
   const showGuardDialog = ref(false)
+  const skipUnsavedConfirmation = ref(
+    typeof window !== 'undefined' && window.localStorage?.getItem(STORAGE_KEY) === 'true'
+  )
   let savedSnapshot = ''
   // Capture the target route, not the `next` callback. Vue Router 4
   // considers `next` consumed once a guard returns `false`; calling
@@ -29,7 +34,7 @@ export function useFormGuard(formData) {
   }, { deep: true })
 
   onBeforeRouteLeave((to) => {
-    if (isDirty.value) {
+    if (isDirty.value && !skipUnsavedConfirmation.value) {
       pendingTo = to
       showGuardDialog.value = true
       return false
@@ -71,5 +76,13 @@ export function useFormGuard(formData) {
     isDirty.value = false
   }
 
-  return { isDirty, showGuardDialog, markClean, confirmLeave, cancelLeave, init }
+  function setSkipUnsavedConfirmation(value) {
+    skipUnsavedConfirmation.value = !!value
+    if (typeof window !== 'undefined' && window.localStorage) {
+      window.localStorage.setItem(STORAGE_KEY, value ? 'true' : 'false')
+    }
+  }
+
+  return { isDirty, showGuardDialog, markClean, confirmLeave, cancelLeave, init,
+           skipUnsavedConfirmation, setSkipUnsavedConfirmation }
 }

--- a/app-ui/src/main/webapp/src/i18n/en.js
+++ b/app-ui/src/main/webapp/src/i18n/en.js
@@ -184,6 +184,8 @@ export default {
   'profile.apiTokens': 'API tokens',
   'profile.apiTokensHint': 'Create or revoke keys for the REST API',
   'profile.theme': 'Theme',
+  'profile.skipUnsavedConfirmation': 'Skip leave confirmation',
+  'profile.skipUnsavedConfirmationHint': 'Leave dirty forms without confirmation prompt',
   'profile.language': 'Language',
 
   // About
@@ -288,6 +290,7 @@ export default {
 
   // Common (additions)
   'common.confirm': 'Confirm',
+  'common.dontAskAgain': "Don't ask again",
 
   // User actions
   'user.actions': 'Actions',

--- a/app-ui/src/main/webapp/src/i18n/fr.js
+++ b/app-ui/src/main/webapp/src/i18n/fr.js
@@ -184,6 +184,8 @@ export default {
   'profile.apiTokens': 'Tokens API',
   'profile.apiTokensHint': 'Créer ou révoquer des clés pour l\'API REST',
   'profile.theme': 'Thème',
+  'profile.skipUnsavedConfirmation': 'Quitter sans confirmation',
+  'profile.skipUnsavedConfirmationHint': 'Quitte les formulaires modifiés sans demander confirmation',
   'profile.language': 'Langue',
 
   // About
@@ -279,6 +281,7 @@ export default {
 
   // Common (additions)
   'common.confirm': 'Confirmer',
+  'common.dontAskAgain': 'Ne plus me demander',
 
   // User actions
   'user.actions': 'Actions',

--- a/app-ui/src/main/webapp/src/views/ProfileView.vue
+++ b/app-ui/src/main/webapp/src/views/ProfileView.vue
@@ -87,7 +87,7 @@
               <v-switch
                 :model-value="skipUnsavedConfirmation"
                 @update:model-value="onSkipUnsavedChange"
-                color="primary"
+                color="success"
                 hide-details
                 density="compact"
                 inset

--- a/app-ui/src/main/webapp/src/views/ProfileView.vue
+++ b/app-ui/src/main/webapp/src/views/ProfileView.vue
@@ -77,6 +77,25 @@
 
             <v-divider class="mb-4" />
 
+            <!-- Skip unsaved-changes confirmation ---------------------- -->
+            <div class="d-flex align-center mb-4">
+              <v-icon class="mr-3">mdi-bell-off-outline</v-icon>
+              <div class="flex-grow-1">
+                <div class="text-subtitle-2">{{ t('profile.skipUnsavedConfirmation') }}</div>
+                <div class="text-caption text-medium-emphasis">{{ t('profile.skipUnsavedConfirmationHint') }}</div>
+              </div>
+              <v-switch
+                :model-value="skipUnsavedConfirmation"
+                @update:model-value="onSkipUnsavedChange"
+                color="primary"
+                hide-details
+                density="compact"
+                inset
+              />
+            </div>
+
+            <v-divider class="mb-4" />
+
             <!-- Theme -------------------------------------------------- -->
             <div class="d-flex align-center mb-3">
               <v-icon class="mr-3">mdi-palette</v-icon>
@@ -106,24 +125,6 @@
                 </v-card>
               </v-col>
             </v-row>
-
-            <v-divider class="my-4" />
-
-            <!-- Skip unsaved-changes confirmation ---------------------- -->
-            <div class="d-flex align-center">
-              <v-icon class="mr-3">mdi-bell-off-outline</v-icon>
-              <div class="flex-grow-1">
-                <div class="text-subtitle-2">{{ t('profile.skipUnsavedConfirmation') }}</div>
-                <div class="text-caption text-medium-emphasis">{{ t('profile.skipUnsavedConfirmationHint') }}</div>
-              </div>
-              <v-switch
-                :model-value="skipUnsavedConfirmation"
-                @update:model-value="onSkipUnsavedChange"
-                hide-details
-                density="compact"
-                inset
-              />
-            </div>
           </v-card-text>
         </v-card>
       </v-col>

--- a/app-ui/src/main/webapp/src/views/ProfileView.vue
+++ b/app-ui/src/main/webapp/src/views/ProfileView.vue
@@ -106,6 +106,24 @@
                 </v-card>
               </v-col>
             </v-row>
+
+            <v-divider class="my-4" />
+
+            <!-- Skip unsaved-changes confirmation ---------------------- -->
+            <div class="d-flex align-center">
+              <v-icon class="mr-3">mdi-bell-off-outline</v-icon>
+              <div class="flex-grow-1">
+                <div class="text-subtitle-2">{{ t('profile.skipUnsavedConfirmation') }}</div>
+                <div class="text-caption text-medium-emphasis">{{ t('profile.skipUnsavedConfirmationHint') }}</div>
+              </div>
+              <v-switch
+                :model-value="skipUnsavedConfirmation"
+                @update:model-value="onSkipUnsavedChange"
+                hide-details
+                density="compact"
+                inset
+              />
+            </div>
           </v-card-text>
         </v-card>
       </v-col>
@@ -114,7 +132,7 @@
 </template>
 
 <script setup>
-import { computed, onMounted } from 'vue'
+import { computed, onMounted, ref } from 'vue'
 import { useTheme } from 'vuetify'
 import { useAuthStore } from '@/stores/auth.js'
 import { useAppStore } from '@/stores/app.js'
@@ -135,6 +153,17 @@ const languageItems = computed(() =>
 function chooseTheme(id) {
   theme.global.name.value = id
   persistTheme(id)
+}
+
+const STORAGE_KEY = 'ligoj.skipUnsavedConfirmation'
+const skipUnsavedConfirmation = ref(
+  typeof window !== 'undefined' && window.localStorage?.getItem(STORAGE_KEY) === 'true'
+)
+function onSkipUnsavedChange(value) {
+  skipUnsavedConfirmation.value = !!value
+  if (typeof window !== 'undefined' && window.localStorage) {
+    window.localStorage.setItem(STORAGE_KEY, value ? 'true' : 'false')
+  }
 }
 
 onMounted(() => {


### PR DESCRIPTION
## Context

Issue ligoj/plugin-id#46 asks for a way to permanently skip the unsaved-changes confirmation dialog. The preference must be persisted in browser storage (like language and theme) and editable from the user profile view.

## Fix

Five files in the core only:

- `useFormGuard.js` reads `ligoj.skipUnsavedConfirmation` from localStorage and skips the dialog when set. Exposes `skipUnsavedConfirmation` ref and `setSkipUnsavedConfirmation(value)` setter.
- `LigojConfirmDialog.vue` gains optional `showSkipForeverCheckbox` and `skipForever` props plus an `update:skipForever` emit. The checkbox is only rendered when the consumer opts in; existing call sites stay unchanged.
- `ProfileView.vue` exposes the preference as a toggle in the Preferences card (next to language and theme) so the user can revert the choice at any time.
- New i18n keys `common.dontAskAgain`, `profile.skipUnsavedConfirmation`, `profile.skipUnsavedConfirmationHint` (FR + EN).

## Out of scope, follow-up

A follow-up PR on plugin-id will wire the checkbox into the existing unsaved-changes dialogs (DelegateEditDialog, UserEditDialog, CompanyEditView, GroupEditView) so the user can also opt in directly from the dialog. For now the profile toggle is enough to cover the main use case.

## Test plan

- npm run build : OK
- npx vitest run : OK (pre-existing plugin-prov/scm-git import failures unrelated to this change)
- Smoke test on the profile view: toggle visible in Preferences card. With toggle ON, leaving a dirty form navigates without the confirmation dialog. With toggle OFF, the dialog reappears.

Closes ligoj/plugin-id#46