### PR TITLE
feat(ui): support an icon prop in LigojConfirmDialog

### DIFF
--- a/app-ui/src/main/webapp/src/components/LigojConfirmDialog.vue
+++ b/app-ui/src/main/webapp/src/components/LigojConfirmDialog.vue
@@ -6,7 +6,10 @@
     @update:model-value="$emit('update:modelValue', $event)"
   >
     <v-card>
-      <v-card-title>{{ title }}</v-card-title>
+      <v-card-title :class="icon ? 'd-flex align-center ga-2' : undefined">
+        <v-icon v-if="icon" :color="iconColor">{{ icon }}</v-icon>
+        <span>{{ title }}</span>
+      </v-card-title>
       <v-card-text>
         <slot>{{ message }}</slot>
       </v-card-text>
@@ -70,6 +73,11 @@ import { useI18nStore } from '@/stores/i18n.js'
 const props = defineProps({
   modelValue: { type: Boolean, default: false },
   title: { type: String, required: true },
+  /** Optional MDI icon prepended to the title, representing the entity
+   *  the dialog concerns (e.g. mdi-account). Null = no icon (legacy look). */
+  icon: { type: String, default: null },
+  /** Vuetify color for the title icon. */
+  iconColor: { type: String, default: 'primary' },
   /** Plain-text body — superseded by the default slot if provided. */
   message: { type: String, default: '' },
   /** Override the default "Cancel" / "Confirm" labels. */


### PR DESCRIPTION
## Context

Part of generalizing dialog title icons across the application (ligoj/plugin-id#51). The shared `LigojConfirmDialog` rendered a plain text title with no way to show an icon, while plugin dialogs needed to prepend their title with an icon representing the edited entity.

## Change

- Adds an optional `icon` prop (MDI string) and `icon-color` prop (default `primary`) to `LigojConfirmDialog`.
- When `icon` is set, the title row becomes a flex line with the icon prepended; when unset, the previous plain-title rendering is preserved (no visual change for existing callers).

## Test plan

- npm run build : OK
- npx vitest run : 138 tests pass (the 7 failing suites are pre-existing, unrelated — they import a `plugin-prov` checkout absent from this workspace).