### PR TITLE
fix(login): play the shine animation only once

### DIFF
--- a/app-ui/src/main/webapp/src/LoginApp.vue
+++ b/app-ui/src/main/webapp/src/LoginApp.vue
@@ -1042,7 +1042,7 @@ input[readonly] {
   height: 100%;
   background: linear-gradient(100deg, transparent, rgba(255, 255, 255, .4), transparent);
   transform: skewX(-20deg);
-  animation: shine 3.6s ease-in-out infinite;
+  animation: shine 3.6s ease-in-out 1;
 }
 
 @keyframes shine {

--- a/app-ui/src/main/webapp/src/views/LoginView.vue
+++ b/app-ui/src/main/webapp/src/views/LoginView.vue
@@ -1106,7 +1106,7 @@ input[readonly] {
   height: 100%;
   background: linear-gradient(100deg, transparent, rgba(255, 255, 255, .4), transparent);
   transform: skewX(-20deg);
-  animation: shine 3.6s ease-in-out infinite;
+  animation: shine 3.6s ease-in-out 1;
 }
 
 @keyframes shine {


### PR DESCRIPTION
Caps the decorative shine sweep on the login button to a single iteration (was `infinite`). Saves CPU/GPU on the idle login screen and removes the visual distraction. Closes #107.