### PR TITLE
feat(ui): add LjStatus shared component for unified status dots

### DIFF
--- a/app-ui/src/main/webapp/src/components/LjStatus.vue
+++ b/app-ui/src/main/webapp/src/components/LjStatus.vue
@@ -1,0 +1,49 @@
+<!--
+  LjStatus — solo status dot + tooltip, the standard for "active / inactive"
+  cells in tables. Replaces the green-light-with-text and v-chip patterns
+  scattered across the application (e.g. SystemNodeView, SystemPluginView).
+
+    <LjStatus :active="row.enabled" :tooltip="t('common.activated')" />
+    <LjStatus :active="false" :tooltip="t('common.disabled')" />
+
+  Renders an inline circular dot: vivid green with a glow when `active`,
+  muted grey otherwise — a 1:1 reuse of the plugin-id DelegateListView
+  `.bdot` pattern (PR #56) so every table reads the same. The tooltip is
+  required for a11y (it carries the meaning the removed text used to).
+
+  Colours/size are exposed as `--lj-status-*` custom properties on the
+  element so a caller can override them locally if ever needed.
+-->
+<template>
+  <span class="lj-status" :class="{ on: active }" role="img" :aria-label="tooltip">
+    <v-tooltip activator="parent" :text="tooltip" location="top" />
+  </span>
+</template>
+
+<script setup>
+defineProps({
+  // true → vivid green + glow, false → muted grey.
+  active: { type: Boolean, default: false },
+  // Required: the status meaning, surfaced on hover (a11y label too).
+  tooltip: { type: String, required: true },
+})
+</script>
+
+<style scoped>
+.lj-status {
+  --lj-status-size: 10px;
+  --lj-status-on: #1d9d63;
+  --lj-status-off: rgba(var(--v-theme-on-surface), .2);
+  --lj-status-glow: 0 0 0 3px rgba(29, 157, 99, .18), 0 0 10px 1px rgba(29, 157, 99, .6);
+  display: inline-block;
+  width: var(--lj-status-size);
+  height: var(--lj-status-size);
+  border-radius: 50%;
+  background: var(--lj-status-off);
+  transition: background .15s, box-shadow .15s;
+}
+.lj-status.on {
+  background: var(--lj-status-on);
+  box-shadow: var(--lj-status-glow);
+}
+</style>

--- a/app-ui/src/main/webapp/src/host.js
+++ b/app-ui/src/main/webapp/src/host.js
@@ -47,6 +47,7 @@ export { default as LjSearch } from './components/LjSearch.vue'
 export { default as LjDialog } from './components/LjDialog.vue'
 export { default as LjSegmented } from './components/LjSegmented.vue'
 export { default as LjAvailabilityField } from './components/LjAvailabilityField.vue'
+export { default as LjStatus } from './components/LjStatus.vue'
 export { nodeType, isInstance, nodePluginId } from './utils/nodeType.js'
 // Registry lookup so a plugin can collaborate with sibling/sub-plugins
 // (e.g. `plugin-id` delegating to `plugin-id-ldap` for tool-specific row


### PR DESCRIPTION
First half of the status icon standardisation (#110 + #111). Adds the LjStatus component to the host, exported via host.js so plugins can consume it.

LjStatus renders a solo coloured dot with a tooltip, replacing the mix of green-light-with-text and v-chip patterns scattered across the application tables. It reuses the existing plugin-id DelegateListView convention 1:1 (vivid green + glow when active, muted grey otherwise, tooltip required for a11y).

API (minimal):
- `active` (Boolean) — true → green, false → grey
- `tooltip` (String, required) — surfaced on hover, also used as aria-label

The application pass (SystemNodeView, SystemPluginView) follows in a companion plugin-ui PR (2/2), which will close both issues.

Refs #110 #111.