### PR TITLE
Extend LjStatus with status prop (ok / warn / error / idle)

### DIFF
--- a/app-ui/src/main/webapp/src/__tests__/components/LjStatus.test.js
+++ b/app-ui/src/main/webapp/src/__tests__/components/LjStatus.test.js
@@ -1,0 +1,60 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import LjStatus from '@/components/LjStatus.vue'
+
+// v-tooltip is a global Vuetify component; stub it so we only assert the dot.
+function render(props) {
+  return mount(LjStatus, {
+    props: { tooltip: 'status', ...props },
+    global: { stubs: { 'v-tooltip': true } },
+  })
+}
+
+describe('<LjStatus />', () => {
+  describe('semantic `status` prop', () => {
+    for (const status of ['ok', 'warn', 'error', 'idle']) {
+      it(`status='${status}' → class lj-status--${status}`, () => {
+        const w = render({ status })
+        expect(w.classes()).toContain(`lj-status--${status}`)
+      })
+    }
+  })
+
+  describe('binary `active` shortcut', () => {
+    it('active=true (no status) → lj-status--ok', () => {
+      const w = render({ active: true })
+      expect(w.classes()).toContain('lj-status--ok')
+    })
+
+    it('active=false (no status) → lj-status--idle', () => {
+      const w = render({ active: false })
+      expect(w.classes()).toContain('lj-status--idle')
+    })
+
+    it('defaults to idle when neither prop is set', () => {
+      const w = render({})
+      expect(w.classes()).toContain('lj-status--idle')
+    })
+  })
+
+  describe('precedence', () => {
+    it('status overrides active', () => {
+      const w = render({ active: true, status: 'error' })
+      expect(w.classes()).toContain('lj-status--error')
+      expect(w.classes()).not.toContain('lj-status--ok')
+    })
+
+    it('reacts to prop changes', async () => {
+      const w = render({ status: 'ok' })
+      expect(w.classes()).toContain('lj-status--ok')
+      await w.setProps({ status: 'warn' })
+      expect(w.classes()).toContain('lj-status--warn')
+    })
+  })
+
+  it('exposes the tooltip as the aria-label', () => {
+    const w = render({ status: 'ok', tooltip: 'Activated' })
+    expect(w.attributes('aria-label')).toBe('Activated')
+    expect(w.attributes('role')).toBe('img')
+  })
+})

--- a/app-ui/src/main/webapp/src/components/LjStatus.vue
+++ b/app-ui/src/main/webapp/src/components/LjStatus.vue
@@ -3,47 +3,77 @@
   cells in tables. Replaces the green-light-with-text and v-chip patterns
   scattered across the application (e.g. SystemNodeView, SystemPluginView).
 
-    <LjStatus :active="row.enabled" :tooltip="t('common.activated')" />
-    <LjStatus :active="false" :tooltip="t('common.disabled')" />
+  Two ways to drive it:
 
-  Renders an inline circular dot: vivid green with a glow when `active`,
-  muted grey otherwise — a 1:1 reuse of the plugin-id DelegateListView
-  `.bdot` pattern (PR #56) so every table reads the same. The tooltip is
-  required for a11y (it carries the meaning the removed text used to).
+  1. Binary (legacy) — `active` boolean, true → green/ok, false → grey/idle:
 
-  Colours/size are exposed as `--lj-status-*` custom properties on the
-  element so a caller can override them locally if ever needed.
+       <LjStatus :active="row.enabled" :tooltip="t('common.activated')" />
+       <LjStatus :active="false" :tooltip="t('common.disabled')" />
+
+  2. Semantic (multi-state) — `status` overrides `active` and accepts
+     'ok' (green) | 'warn' (orange) | 'error' (red) | 'idle' (grey), for
+     tri-state cases like the plugin lifecycle or `locked = error`:
+
+       <LjStatus status="warn" :tooltip="t('plugin.idle')" />
+       <LjStatus :status="row.locked ? 'error' : 'ok'" :tooltip="..." />
+
+  Renders an inline circular dot with a matching glow — a 1:1 reuse of the
+  plugin-id DelegateListView `.bdot` pattern (PR #56) so every table reads
+  the same. The tooltip is required for a11y (it carries the meaning the
+  removed text used to).
+
+  Size is exposed as the `--lj-status-size` custom property on the element
+  so a caller can override it locally if ever needed.
 -->
 <template>
-  <span class="lj-status" :class="{ on: active }" role="img" :aria-label="tooltip">
+  <span class="lj-status" :class="`lj-status--${resolved}`" role="img" :aria-label="tooltip">
     <v-tooltip activator="parent" :text="tooltip" location="top" />
   </span>
 </template>
 
 <script setup>
-defineProps({
-  // true → vivid green + glow, false → muted grey.
+import { computed } from 'vue'
+
+const props = defineProps({
+  // Binary shortcut: true → 'ok', false → 'idle'. Ignored when `status` is set.
   active: { type: Boolean, default: false },
+  // Semantic state; overrides `active` when provided.
+  status: {
+    type: String,
+    default: null,
+    validator: (v) => v === null || ['ok', 'warn', 'error', 'idle'].includes(v),
+  },
   // Required: the status meaning, surfaced on hover (a11y label too).
   tooltip: { type: String, required: true },
 })
+
+// `status` wins; otherwise fall back to the binary `active` mapping.
+const resolved = computed(() => props.status ?? (props.active ? 'ok' : 'idle'))
 </script>
 
 <style scoped>
 .lj-status {
   --lj-status-size: 10px;
-  --lj-status-on: #1d9d63;
-  --lj-status-off: rgba(var(--v-theme-on-surface), .2);
-  --lj-status-glow: 0 0 0 3px rgba(29, 157, 99, .18), 0 0 10px 1px rgba(29, 157, 99, .6);
   display: inline-block;
   width: var(--lj-status-size);
   height: var(--lj-status-size);
   border-radius: 50%;
-  background: var(--lj-status-off);
+  background: rgba(var(--v-theme-on-surface), .2);
   transition: background .15s, box-shadow .15s;
 }
-.lj-status.on {
-  background: var(--lj-status-on);
-  box-shadow: var(--lj-status-glow);
+.lj-status--ok {
+  background: #1d9d63;
+  box-shadow: 0 0 0 3px rgba(29, 157, 99, .18), 0 0 10px 1px rgba(29, 157, 99, .6);
+}
+.lj-status--warn {
+  background: #df8a42;
+  box-shadow: 0 0 0 3px rgba(223, 138, 66, .18), 0 0 10px 1px rgba(223, 138, 66, .6);
+}
+.lj-status--error {
+  background: #df4d42;
+  box-shadow: 0 0 0 3px rgba(223, 77, 66, .18), 0 0 10px 1px rgba(223, 77, 66, .6);
+}
+.lj-status--idle {
+  background: rgba(var(--v-theme-on-surface), .2);
 }
 </style>


### PR DESCRIPTION
Adds a `status` prop to `LjStatus` accepting `ok` / `warn` / `error` / `idle`. The existing `active` boolean stays backwards-compatible (maps to `ok` / `idle`).

New CSS classes `.lj-status--{ok,warn,error,idle}` map to semantic colors.

Unlocks the standardisation work in ligoj-plugins#110 and ligoj-plugins#111.

File: `app-ui/src/main/webapp/src/components/LjStatus.vue` + 10 new test cases.