### PR TITLE
feat(profile): display API authorizations on /profile

### DIFF
--- a/app-ui/src/main/webapp/src/i18n/en.js
+++ b/app-ui/src/main/webapp/src/i18n/en.js
@@ -187,6 +187,7 @@ export default {
   'profile.roles': 'Roles',
   'profile.permissions': 'Permissions',
   'profile.uiAuth': 'UI Authorizations ({{count}})',
+  'profile.apiAuth': 'API Authorizations ({{count}})',
   'profile.preferences': 'Preferences',
   'profile.apiTokens': 'API tokens',
   'profile.apiTokensHint': 'Create or revoke keys for the REST API',

--- a/app-ui/src/main/webapp/src/i18n/fr.js
+++ b/app-ui/src/main/webapp/src/i18n/fr.js
@@ -187,6 +187,7 @@ export default {
   'profile.roles': 'Rôles',
   'profile.permissions': 'Permissions',
   'profile.uiAuth': 'Autorisations UI ({{count}})',
+  'profile.apiAuth': 'Autorisations API ({{count}})',
   'profile.preferences': 'Préférences',
   'profile.apiTokens': 'Tokens API',
   'profile.apiTokensHint': 'Créer ou révoquer des clés pour l\'API REST',

--- a/app-ui/src/main/webapp/src/views/ProfileView.vue
+++ b/app-ui/src/main/webapp/src/views/ProfileView.vue
@@ -28,13 +28,19 @@
         <h3><span class="ic"><v-icon>mdi-key</v-icon></span>{{ t('profile.permissions') }}</h3>
         <div class="subhead">{{ t('profile.uiAuth', { count: auth.uiAuthorizations.length }) }}</div>
         <div class="perm-list">
-          <code v-for="(pattern, i) in auth.uiAuthorizations" :key="'ui-' + i" class="perm">{{ pattern }}</code>
+          <code v-for="(pattern, i) in auth.uiAuthorizations" :key="'ui-' + i" class="perm">
+            <span v-for="(token, j) in tokenizePattern(pattern)" :key="j"
+                  :class="'token token--' + token.type">{{ token.value }}</span>
+          </code>
         </div>
         <div class="subhead subhead--api">{{ t('profile.apiAuth', { count: auth.apiAuthorizations.length }) }}</div>
         <div class="perm-list">
           <code v-for="(entry, i) in auth.apiAuthorizations" :key="'api-' + i" class="perm perm--api">
             <span class="method" :class="methodClass(entry.method)">{{ entry.method || '?' }}</span>
-            <span class="pattern">{{ entry.pattern }}</span>
+            <span class="pattern">
+              <span v-for="(token, j) in apiTokens(entry.pattern)" :key="j"
+                    :class="'token token--' + token.type">{{ token.value }}</span>
+            </span>
           </code>
         </div>
       </section>
@@ -107,6 +113,40 @@ const initials = computed(() => (auth.userName || '?').slice(0, 2).toUpperCase()
 
 function methodClass(method) {
   return method ? `method--${method.toLowerCase()}` : ''
+}
+
+// Detect regex special tokens; everything else stays literal.
+const TOKEN_RE = /(\\.|\^|\$|\.[*+?]|\.|\*|\+|\?|\([^)]*\)|\[[^\]]*\]|\{[\d,]+\})/g
+
+function tokenizePattern(pattern) {
+  if (!pattern) return []
+  const tokens = []
+  let lastIndex = 0
+  let match
+  TOKEN_RE.lastIndex = 0
+  while ((match = TOKEN_RE.exec(pattern)) !== null) {
+    if (match.index > lastIndex) {
+      tokens.push({ type: 'literal', value: pattern.slice(lastIndex, match.index) })
+    }
+    tokens.push({ type: 'regex', value: match[0] })
+    lastIndex = TOKEN_RE.lastIndex
+  }
+  if (lastIndex < pattern.length) {
+    tokens.push({ type: 'literal', value: pattern.slice(lastIndex) })
+  }
+  return tokens
+}
+
+// Strip the `^rest/` / `^rest$` prefix common to every API permission;
+// it's the same for every entry so it carries no information.
+function prettyApiPattern(pattern) {
+  if (!pattern) return ''
+  if (pattern === '^rest$') return '/'
+  return pattern.replace(/^\^rest\//, '/')
+}
+
+function apiTokens(pattern) {
+  return tokenizePattern(prettyApiPattern(pattern))
 }
 
 const preset = ref(detectPreset().id)
@@ -240,6 +280,12 @@ onBeforeUnmount(() => { if (typeof document !== 'undefined') document.removeEven
 .perm--api .method--delete { background: #f44336; }
 .perm--api .method--head,
 .perm--api .method--options { background: #607d8b; }
+.token { white-space: pre; }
+.token--literal { color: var(--ink); }
+.token--regex {
+  color: rgb(var(--v-theme-primary));
+  font-weight: 600;
+}
 
 .pref-row { display: flex; align-items: center; gap: 14px; padding: 14px 0; }
 .pref-row + .pref-row, .pref-theme-label { border-top: 1px solid var(--line); }

--- a/app-ui/src/main/webapp/src/views/ProfileView.vue
+++ b/app-ui/src/main/webapp/src/views/ProfileView.vue
@@ -30,6 +30,13 @@
         <div class="perm-list">
           <code v-for="(pattern, i) in auth.uiAuthorizations" :key="'ui-' + i" class="perm">{{ pattern }}</code>
         </div>
+        <div class="subhead subhead--api">{{ t('profile.apiAuth', { count: auth.apiAuthorizations.length }) }}</div>
+        <div class="perm-list">
+          <code v-for="(entry, i) in auth.apiAuthorizations" :key="'api-' + i" class="perm perm--api">
+            <span class="method" :class="methodClass(entry.method)">{{ entry.method || '?' }}</span>
+            <span class="pattern">{{ entry.pattern }}</span>
+          </code>
+        </div>
       </section>
 
       <section class="pcard pcard--full">
@@ -97,6 +104,10 @@ const theme = useTheme()
 const t = i18n.t
 
 const initials = computed(() => (auth.userName || '?').slice(0, 2).toUpperCase())
+
+function methodClass(method) {
+  return method ? `method--${method.toLowerCase()}` : ''
+}
 
 const preset = ref(detectPreset().id)
 function choosePreset(id) { preset.value = id; applyPreset(id, theme); persistPreset(id) }
@@ -197,8 +208,38 @@ onBeforeUnmount(() => { if (typeof document !== 'undefined') document.removeEven
 .infoline.link .v { color: var(--primary); cursor: pointer; }
 
 .subhead { font-size: 12px; font-weight: 700; text-transform: uppercase; letter-spacing: .05em; color: var(--muted); margin-bottom: 10px; }
+.subhead--api { margin-top: 16px; }
 .perm-list { display: flex; flex-direction: column; gap: 6px; max-height: 220px; overflow: auto; }
 .perm { font-family: var(--mono); font-size: 12px; color: var(--muted); background: var(--pill); border: var(--border-w) var(--lj-border-style, solid) var(--border-c); border-radius: var(--radius-sm); padding: 5px 10px; }
+.perm--api {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+}
+.perm--api .method {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: .04em;
+  padding: 2px 6px;
+  border-radius: var(--radius-sm);
+  color: #fff;
+  font-family: var(--font);
+  text-transform: uppercase;
+  flex: none;
+  background: rgba(var(--v-theme-on-surface), .45); /* fallback méthode inconnue */
+}
+.perm--api .pattern {
+  font-family: var(--mono);
+  color: var(--muted);
+}
+.perm--api .method--get { background: #2196f3; }
+.perm--api .method--post { background: #4caf50; }
+.perm--api .method--put { background: #ff9800; }
+.perm--api .method--patch { background: #9c27b0; }
+.perm--api .method--delete { background: #f44336; }
+.perm--api .method--head,
+.perm--api .method--options { background: #607d8b; }
 
 .pref-row { display: flex; align-items: center; gap: 14px; padding: 14px 0; }
 .pref-row + .pref-row, .pref-theme-label { border-top: 1px solid var(--line); }


### PR DESCRIPTION
## Context

Issue: ligoj/plugin-ui#19 — the `/profile` page Permissions card was
showing only UI authorizations (count + list). The session payload
already includes API authorizations and the auth store exposes them
via `auth.apiAuthorizations`, but the view never rendered them.

The issue requests the missing API counter. This PR adds it, plus the
natural list block underneath (matching the existing UI counter+list
pattern), and a small readability polish on both lists.

## Scope decisions

The change is split into two commits to make the polish revert-friendly
if a stricter scope is preferred:

- **Commit 1 (`feat`) strictly addresses the issue.** It adds the API
  counter and the API list. Because `apiAuthorizations` carries objects
  of shape `{ pattern, method }` (unlike `uiAuthorizations` which is a
  list of strings), a minimal visual decision had to be made for how to
  render the HTTP method alongside the pattern — hence the colored
  method badge (Swagger / Postman / Insomnia convention: GET blue, POST
  green, PUT orange, PATCH purple, DELETE red, HEAD / OPTIONS gray).

- **Commit 2 (`style`) is pure polish, isolated so it can be reverted
  on its own** without touching the counter or list:
  - Tokenize each pattern into literal and regex segments; render
    regex chars (`.*`, `^`, `$`, `(...)`, `[...]`, etc.) in the theme
    accent and the literal path in surface ink, for a clearer
    signal-to-noise hierarchy.
  - Strip the `^rest/` prefix from API patterns (replaced by a leading
    `/`); every API permission shares the prefix, so it carries no
    information.

The polish is applied to both UI and API patterns for consistency.

## Changes

### Commit 1 — `feat(profile): display API authorizations counter and list`

- `app-ui/src/main/webapp/src/i18n/{fr,en}.js` : new `profile.apiAuth`
  key matching the existing `profile.uiAuth` pattern.
- `app-ui/src/main/webapp/src/views/ProfileView.vue` :
  - Permissions card: second subhead + perm-list block for API
    authorizations, rendered as `<method badge> <pattern>`.
  - `methodClass(method)` helper resolves the badge color class.
  - CSS: `.subhead--api { margin-top: 16px }` to space the two lists;
    `.perm--api` flex layout; `.method--<verb>` color rules with a
    muted fallback for unknown methods.

### Commit 2 — `style(profile): tokenize permission patterns for readability`

- `app-ui/src/main/webapp/src/views/ProfileView.vue` :
  - `tokenizePattern(pattern)` splits a regex pattern into literal and
    regex tokens.
  - `prettyApiPattern(pattern)` strips `^rest/` (and `^rest$` → `/`).
  - `apiTokens(pattern)` composes the two for API entries.
  - Both UI and API list items render `<span v-for=token>` with
    `.token--literal` / `.token--regex` classes.
  - CSS: `.token--regex` uses `rgb(var(--v-theme-primary))` so the
    accent color follows the active theme.

## Design rationale

- **Method badge colors are hardcoded by design.** HTTP method colors
  are a cross-tool convention (Swagger, Postman, Insomnia) — keeping
  the same palette gives instant recognition. They are intentionally
  not bound to Vuetify theme variables.
- **Token accent uses the theme primary.** Regex highlighting follows
  the user's chosen theme so the polish doesn't fight dark mode or
  alternative palettes.
- **Strip applies only to API patterns.** UI permissions don't share a
  stable prefix, so stripping there would be inconsistent or
  misleading.
- **No breadcrumb rendering.** A regex pattern is not a URL path, so
  segmenting on `/` with chevrons would suggest a path semantic that
  doesn't exist (matching is greedy over the whole expression). The
  expression is kept as a regex visually but highlighted.
- **Unknown HTTP methods get a muted fallback** rather than no badge,
  so the row layout stays stable.

## What's not in this PR

- No backend or REST API change. The data was already in the session
  payload.
- No new i18n key besides `profile.apiAuth`. HTTP method labels and
  regex patterns are intentionally not translated.
- No change to the UI counter, the existing UI list, or any other
  view.
- No change outside `ProfileView.vue` and the two i18n files.

## Tests

- `npx vitest run` — 181 passing (23 files), 0 failing.
- `npm run build` — success.
- `mvn install -DskipTests` — BUILD SUCCESS.
- Runtime smoke test on `/profile` :
  - FR and EN — both subheads, counters, badges, and tokenized
    patterns render correctly.
  - Ligoj Classic (light) and Ligoj Dark (dark) — token accent tracks
    the theme primary correctly.
  - HTTP methods covered by test session: GET, POST, PUT, PATCH,
    DELETE.

## Feedback welcome

Happy to drop Commit 2 if the literal regex string is preferred, or to
reduce the badge palette to a single neutral chip. Not opinionated on
either — Commit 1 is the answer to the filed issue; Commit 2 was added
because the method badge already brought structure to the API row and
the tokenizer felt natural to extend.
