### PR TITLE
feat(profile): add reduce-motion accessibility toggle

### DIFF
--- a/app-ui/src/main/webapp/src/__tests__/plugins/styles.test.js
+++ b/app-ui/src/main/webapp/src/__tests__/plugins/styles.test.js
@@ -1,0 +1,48 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import {
+  detectReduceMotion,
+  persistReduceMotion,
+  applyReduceMotion,
+  bootReduceMotion,
+} from '@/plugins/styles.js'
+
+const KEY = 'ligoj-reduce-motion'
+
+describe('reduce-motion toggle', () => {
+  beforeEach(() => {
+    // Vitest provides happy-dom: localStorage + document exist.
+    localStorage.removeItem(KEY)
+    delete document.documentElement.dataset.reduceMotion
+  })
+
+  it('detect defaults to false when storage is empty', () => {
+    expect(detectReduceMotion()).toBe(false)
+  })
+
+  it('detect reads true only for the exact "true" string', () => {
+    localStorage.setItem(KEY, 'true')
+    expect(detectReduceMotion()).toBe(true)
+    localStorage.setItem(KEY, 'false')
+    expect(detectReduceMotion()).toBe(false)
+  })
+
+  it('persist writes "true"/"false" mirroring the boolean', () => {
+    persistReduceMotion(true)
+    expect(localStorage.getItem(KEY)).toBe('true')
+    persistReduceMotion(false)
+    expect(localStorage.getItem(KEY)).toBe('false')
+  })
+
+  it('apply sets the html data attribute and removes it when off', () => {
+    applyReduceMotion(true)
+    expect(document.documentElement.dataset.reduceMotion).toBe('true')
+    applyReduceMotion(false)
+    expect(document.documentElement.dataset.reduceMotion).toBeUndefined()
+  })
+
+  it('boot reads storage, applies it, and returns the value', () => {
+    localStorage.setItem(KEY, 'true')
+    expect(bootReduceMotion()).toBe(true)
+    expect(document.documentElement.dataset.reduceMotion).toBe('true')
+  })
+})

--- a/app-ui/src/main/webapp/src/assets/vuetify-overrides.css
+++ b/app-ui/src/main/webapp/src/assets/vuetify-overrides.css
@@ -383,6 +383,35 @@
   display: none !important;
 }
 
+/* ========================== reduce motion ===============================
+ * Orthogonal global accessibility toggle — see `applyReduceMotion()` in
+ * `plugins/styles.js`. Lives at `[data-reduce-motion="true"]` so it layers
+ * over any preset. Kills ripples, dialog/menu appear animations (including
+ * the bespoke `vc-shake` on destructive VibrantConfirmDialog) and progress
+ * bar motion. The global reset below already neutralizes most of these via
+ * the near-zero duration; the targeted rules make the intent explicit and
+ * cover keyframe animations that ignore `transition-duration`.
+ * ======================================================================== */
+[data-reduce-motion="true"] *,
+[data-reduce-motion="true"] *::before,
+[data-reduce-motion="true"] *::after {
+  animation-duration: .001ms !important;
+  animation-iteration-count: 1 !important;
+  transition-duration: .001ms !important;
+  scroll-behavior: auto !important;
+}
+[data-reduce-motion="true"] .v-ripple__container {
+  display: none !important;
+}
+[data-reduce-motion="true"] .v-progress-linear__indeterminate,
+[data-reduce-motion="true"] .v-progress-circular__overlay {
+  animation: none !important;
+}
+[data-reduce-motion="true"] .vconfirm.tone-error,
+[data-reduce-motion="true"] .vconfirm.tone-warning {
+  animation: none !important;
+}
+
 /* ============================== sharp ====================================
  * Brutalist. Zero radius, monospaced labels, harsh borders, uppercase
  * buttons. Reads like a 90s admin panel reskinned for 2026 — a love-it-or-

--- a/app-ui/src/main/webapp/src/i18n/en.js
+++ b/app-ui/src/main/webapp/src/i18n/en.js
@@ -196,6 +196,8 @@ export default {
   'profile.theme': 'Theme',
   'profile.compact': 'Compact mode',
   'profile.compactHint': 'Tighter spacing, smaller fonts, denser tables',
+  'profile.reduceMotion': 'Reduce motion',
+  'profile.reduceMotionHint': 'Disable ripples, dialog and menu animations, and progress bar motion',
   'profile.skipUnsavedConfirmation': 'Skip leave confirmation',
   'profile.skipUnsavedConfirmationHint': 'Leave dirty forms without confirmation prompt',
   'profile.language': 'Language',

--- a/app-ui/src/main/webapp/src/i18n/fr.js
+++ b/app-ui/src/main/webapp/src/i18n/fr.js
@@ -196,6 +196,8 @@ export default {
   'profile.theme': 'Thème',
   'profile.compact': 'Mode compact',
   'profile.compactHint': 'Espacements resserrés, polices plus petites, tableaux plus denses',
+  'profile.reduceMotion': 'Réduire les animations',
+  'profile.reduceMotionHint': 'Désactive les effets ripple, les animations de dialogs et menus, et la barre de progression',
   'profile.skipUnsavedConfirmation': 'Quitter sans confirmation',
   'profile.skipUnsavedConfirmationHint': 'Quitte les formulaires modifiés sans demander confirmation',
   'profile.language': 'Langue',

--- a/app-ui/src/main/webapp/src/main.js
+++ b/app-ui/src/main/webapp/src/main.js
@@ -6,7 +6,7 @@ import i18n from './plugins/i18n.js'
 import router from './router/index.js'
 import { loadAllPlugins } from './plugins/loader.js'
 import { registerBuiltinPlugins } from './plugins/index.js'
-import { bootCompact } from './plugins/styles.js'
+import { bootCompact, bootReduceMotion } from './plugins/styles.js'
 import { bootPreset } from './plugins/presets.js'
 
 // Apply the persisted theme preset (color palette + shape style) and
@@ -17,6 +17,7 @@ import { bootPreset } from './plugins/presets.js'
 // — set by `plugins/vuetify.js` from the same persisted preset id.
 bootPreset()
 bootCompact()
+bootReduceMotion()
 
 const app = createApp(App)
 const pinia = createPinia()

--- a/app-ui/src/main/webapp/src/plugins/styles.js
+++ b/app-ui/src/main/webapp/src/plugins/styles.js
@@ -16,6 +16,7 @@
 
 const STORAGE_KEY = 'ligoj-style'
 const COMPACT_KEY = 'ligoj-compact'
+const REDUCE_MOTION_KEY = 'ligoj-reduce-motion'
 
 /**
  * Public style catalog. Order is the picker order: keep "default"
@@ -196,5 +197,47 @@ export function applyCompact(value) {
 export function bootCompact() {
   const v = detectCompact()
   applyCompact(v)
+  return v
+}
+
+/* ===========================================================================
+ * Reduce motion — orthogonal global toggle
+ *
+ * Same shape as the compact toggle: an accessibility preference that layers
+ * over every preset via `<html data-reduce-motion="true">`. The matching CSS
+ * lives at `[data-reduce-motion="true"]` in `assets/vuetify-overrides.css`
+ * and kills ripples, dialog/menu animations and progress-bar motion. It
+ * complements the OS-level `prefers-reduced-motion` media query by giving
+ * users an in-app switch independent of their system setting.
+ * ========================================================================= */
+
+export function detectReduceMotion() {
+  if (typeof localStorage === 'undefined') return false
+  return localStorage.getItem(REDUCE_MOTION_KEY) === 'true'
+}
+
+export function persistReduceMotion(value) {
+  if (typeof localStorage === 'undefined') return
+  localStorage.setItem(REDUCE_MOTION_KEY, value ? 'true' : 'false')
+}
+
+/**
+ * Flip `<html data-reduce-motion="…">`. We set/remove the attribute
+ * (instead of writing "false") so CSS rules can use the cleaner
+ * `[data-reduce-motion="true"]` selector without an extra "not('false')"
+ * guard.
+ */
+export function applyReduceMotion(value) {
+  if (typeof document === 'undefined') return
+  if (value) {
+    document.documentElement.dataset.reduceMotion = 'true'
+  } else {
+    delete document.documentElement.dataset.reduceMotion
+  }
+}
+
+export function bootReduceMotion() {
+  const v = detectReduceMotion()
+  applyReduceMotion(v)
   return v
 }

--- a/app-ui/src/main/webapp/src/views/ProfileView.vue
+++ b/app-ui/src/main/webapp/src/views/ProfileView.vue
@@ -55,6 +55,15 @@
           <span class="sw" :class="{ on: compact }" role="switch" :aria-checked="compact" @click="onCompactChange(!compact)"></span>
         </div>
 
+        <div class="pref-row">
+          <v-icon class="pref-ic">mdi-motion-pause-outline</v-icon>
+          <div class="pt">
+            <div class="ptt">{{ t('profile.reduceMotion') }}</div>
+            <div class="pth">{{ t('profile.reduceMotionHint') }}</div>
+          </div>
+          <span class="sw" :class="{ on: reduceMotion }" role="switch" :aria-checked="reduceMotion" @click="onReduceMotionChange(!reduceMotion)"></span>
+        </div>
+
         <div class="pref-theme-label"><v-icon class="pref-ic">mdi-palette</v-icon>{{ t('profile.theme') }}</div>
         <div class="tiles">
           <button v-for="(opt, i) in PRESET_OPTIONS" :key="opt.id" type="button" class="swatch" :class="{ on: preset === opt.id }" :style="{ '--i': i }" :title="opt.description"
@@ -106,7 +115,7 @@ import { useAuthStore } from '@/stores/auth.js'
 import { useI18nStore } from '@/stores/i18n.js'
 import { useAppStore } from '@/stores/app.js'
 import { PRESET_OPTIONS, detectPreset, applyPreset, persistPreset } from '@/plugins/presets.js'
-import { detectCompact, applyCompact, persistCompact } from '@/plugins/styles.js'
+import { detectCompact, applyCompact, persistCompact, detectReduceMotion, applyReduceMotion, persistReduceMotion } from '@/plugins/styles.js'
 
 const auth = useAuthStore()
 const i18n = useI18nStore()
@@ -170,6 +179,9 @@ function bandBg(opt) {
 
 const compact = ref(detectCompact())
 function onCompactChange(value) { compact.value = !!value; applyCompact(compact.value); persistCompact(compact.value) }
+
+const reduceMotion = ref(detectReduceMotion())
+function onReduceMotionChange(value) { reduceMotion.value = !!value; applyReduceMotion(reduceMotion.value); persistReduceMotion(reduceMotion.value) }
 
 const LOCALE_LABELS = { en: 'English', fr: 'Français' }
 const FLAGS = { en: '🇬🇧', fr: '🇫🇷' }


### PR DESCRIPTION
## Context
Adds an in-app "Reduce motion" accessibility option in the user profile,
as requested in ligoj/plugin-ui#29. The whole change lives in the host
(app-ui) since the profile view, themes and ripple all live here — the
plugin-ui issue tracks UI behaviour, not plugin-ui code.

## Scope decisions
- The toggle is a manual switch (iOS-style), default OFF, even when the OS
  already reports `prefers-reduced-motion: reduce`. The existing OS-level
  `@media` guard is kept untouched; this option is an independent in-app
  override. Tell me if you'd rather default it ON when the OS prefers it.
- Preference is stored in localStorage (device-level), consistent with the
  sibling preferences (compact mode, style, locale).

## Changes
- `plugins/styles.js` — new `ligoj-reduce-motion` key + detect/persist/apply/
  boot functions, copied 1:1 on the compact-mode pattern. Applied via
  `<html data-reduce-motion="true">`.
- `main.js` — `bootReduceMotion()` called right after `bootCompact()` (before
  mount, so no flash on reload).
- `views/ProfileView.vue` — new switch row after "Compact mode".
- `assets/vuetify-overrides.css` — `[data-reduce-motion="true"]` block: global
  transition/animation reset + ripple hidden + progress-bar motion stopped +
  explicit neutralisation of the bespoke `vc-shake` on destructive dialogs.
  `VibrantConfirmDialog.vue` itself is untouched.
- `i18n/en.js` + `i18n/fr.js` — `profile.reduceMotion` / `…Hint`.
- `__tests__/plugins/styles.test.js` — new unit tests for the toggle (5 cases).

## Design rationale
The global near-zero `transition-duration` + single-iteration animation reset
is the workhorse (it covers Vuetify dialog scale, menu transitions and the
indeterminate progress sub-elements). The targeted rules (ripple, progress,
vc-shake) are explicit belt-and-suspenders on top.

## What's not in this PR
- No change to the OS `prefers-reduced-motion` behaviour.
- No server-side / per-account persistence (kept localStorage like siblings).
- `VibrantConfirmDialog.vue` not modified (handled via CSS override).

## Tests
- `npx vitest run` : 186 tests pass (incl. the new styles.test.js).
- `npm run build` : success.
- Runtime: toggle on /profile verified via DOM probes — ripple hidden,
  transitions ~0, progress + shake animations off, persistence across reload,
  full restore on toggle off.

## Note
Base is `feature/vuejs` and the issue is in another repo, so GitHub won't
auto-close it. Refs ligoj/plugin-ui#29 — to be closed manually after merge.

Feedback welcome — if any part feels out of scope, it's an isolated single
commit and can be reverted cleanly.