### PR TITLE
feat(theme): add Reforged preset reviving the legacy Material look

### DIFF
--- a/app-ui/src/main/webapp/src/__tests__/plugins/presets.test.js
+++ b/app-ui/src/main/webapp/src/__tests__/plugins/presets.test.js
@@ -60,6 +60,23 @@ describe('PRESET_OPTIONS', () => {
     }
   })
 
+  it('ships the "Reforged" preset (reforged) wired to ligojClassic + ligoj-classic style', () => {
+    const p = PRESET_OPTIONS.find((x) => x.id === 'reforged')
+    expect(p, 'preset reforged is missing').toBeTruthy()
+    expect(p.theme).toBe('ligojClassic')
+    expect(p.style).toBe('ligoj-classic')
+    // The style must exist in the catalog, else applyStyle() rejects it.
+    expect(STYLE_OPTIONS.some((s) => s.id === 'ligoj-classic')).toBe(true)
+  })
+
+  it('keeps the default preset (ligoj-classic) on ligojLight + default style, now labelled "Ligoj"', () => {
+    const def = PRESET_OPTIONS.find((x) => x.id === DEFAULT_PRESET_ID)
+    expect(def.id).toBe('ligoj-classic')
+    expect(def.label).toBe('Ligoj')
+    expect(def.theme).toBe('ligojLight')
+    expect(def.style).toBe('default')
+  })
+
   it('detectPreset returns the default when storage is empty', () => {
     // Vitest provides happy-dom by default, so localStorage exists.
     localStorage.removeItem('ligoj-preset')

--- a/app-ui/src/main/webapp/src/assets/vuetify-overrides.css
+++ b/app-ui/src/main/webapp/src/assets/vuetify-overrides.css
@@ -1117,3 +1117,156 @@
     opacity: 0;
   }
 }
+
+/* ===========================================================================
+ * ligoj-classic — faithful Bootstrap + Material Design revival
+ *
+ * Selected by `<html data-style="ligoj-classic">` (preset "Reforged",
+ * id `reforged`). Reproduces the spirit of the legacy
+ * `themes/bootstrap-material-design` skin: purple primary, teal accents,
+ * flat indigo sidebar, Material ripples on press and a modal scale-in on dialogs.
+ * Colors are the exact legacy values. The ripple timing mirrors the old
+ * `ripples.css` (opacity .15s ease-in + transform .5s cubic-bezier(.4,0,.2,1)
+ * .1s); the dialog entrance + shadow mirror the old `.modal-content`. Every
+ * rule is scoped under the attribute so other presets stay untouched.
+ * ========================================================================= */
+
+/* a) Ripple on real Vuetify components — mirror the legacy ripples.css feel
+ * (Vuetify's v-ripple directive drives the geometry; we only tune timing). */
+[data-style="ligoj-classic"] .v-ripple__animation--in {
+  transition:
+    transform .5s cubic-bezier(.4, 0, .2, 1) .1s,
+    opacity .15s ease-in !important;
+  opacity: .18;
+}
+[data-style="ligoj-classic"] .v-ripple__animation--out {
+  transition: opacity .1s linear !important;
+}
+
+/* a') Ripple on the 2026 custom controls (plain elements with no v-ripple):
+ * same pure-CSS centered ripple as md3, tuned to the legacy feel. */
+[data-style="ligoj-classic"] .lj-btn,
+[data-style="ligoj-classic"] .lj-iconbtn,
+[data-style="ligoj-classic"] .nav-item,
+[data-style="ligoj-classic"] .sub-item {
+  position: relative;
+  overflow: hidden;
+}
+[data-style="ligoj-classic"] .lj-btn::after,
+[data-style="ligoj-classic"] .lj-iconbtn::after,
+[data-style="ligoj-classic"] .nav-item::after,
+[data-style="ligoj-classic"] .sub-item::after {
+  content: "";
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  width: 100%;
+  aspect-ratio: 1;
+  border-radius: 50%;
+  background: currentColor;
+  opacity: 0;
+  transform: translate(-50%, -50%) scale(3);
+  transform-origin: center;
+  pointer-events: none;
+  transition: transform .5s cubic-bezier(.4, 0, .2, 1), opacity .6s linear;
+}
+[data-style="ligoj-classic"] .lj-btn:active::after,
+[data-style="ligoj-classic"] .lj-iconbtn:active::after,
+[data-style="ligoj-classic"] .nav-item:active::after,
+[data-style="ligoj-classic"] .sub-item:active::after {
+  opacity: .2;
+  transform: translate(-50%, -50%) scale(.2);
+  transition: none;
+}
+[data-style="ligoj-classic"] .lj-btn > *,
+[data-style="ligoj-classic"] .lj-iconbtn > *,
+[data-style="ligoj-classic"] .nav-item > *,
+[data-style="ligoj-classic"] .sub-item > * {
+  position: relative;
+  z-index: 1;
+}
+
+/* b) Dialog scale-in — faithful to the legacy `.modal-content` entrance
+ * (Material modal scale-in + deep elevation, 2px corners). */
+@keyframes lj-classic-dialog {
+  from { transform: scale(.7); opacity: 0; }
+  to   { transform: scale(1);  opacity: 1; }
+}
+[data-style="ligoj-classic"] .v-overlay__content > .v-card {
+  animation: lj-classic-dialog .3s cubic-bezier(.4, 0, .2, 1);
+  border-radius: 2px;
+  box-shadow:
+    0 27px 24px 0 rgba(0, 0, 0, .2),
+    0 40px 77px 0 rgba(0, 0, 0, .22);
+}
+
+/* c) Component colors — exact legacy values. */
+[data-style="ligoj-classic"] .v-chip {
+  background: #0aa89e;
+  color: #fff;
+}
+/* Checked checkbox + focused input underline/label → teal. */
+[data-style="ligoj-classic"] .v-selection-control--dirty .v-selection-control__input {
+  color: #039588;
+}
+[data-style="ligoj-classic"] .v-field--focused .v-field__outline {
+  color: #039588;
+}
+[data-style="ligoj-classic"] .v-field--focused .v-label.v-field-label {
+  color: #039588;
+}
+/* Menus (selects / dropdowns): light grey fill, teal text, purple active.
+ * Descendant selector: the menu's v-list sits under a .v-sheet wrapper inside
+ * .v-overlay__content, not as a direct child. */
+[data-style="ligoj-classic"] .v-overlay__content .v-list {
+  background: #eeeeee !important;
+}
+[data-style="ligoj-classic"] .v-overlay__content .v-list-item:not(.v-list-item--active) {
+  color: #039588;
+}
+[data-style="ligoj-classic"] .v-list-item--active {
+  background: #9c27b0 !important;
+  color: #fff !important;
+}
+/* Sidebar (the host chrome) → flat indigo. App.vue paints the rail with a
+ * gradient derived from --primary (line ~455); under this theme that primary
+ * is purple (#9c27b0), which reads garish, so we flatten it to a solid indigo
+ * #3f51b5 — the legacy "toolbar" color, moved onto the real chrome. The top
+ * bar (header.bar) is intentionally left light/default for an indigo-rail +
+ * light-content contrast, like the old UI. */
+[data-style="ligoj-classic"] .sidebar {
+  background: #3f51b5 !important;
+}
+[data-style="ligoj-classic"] .sidebar,
+[data-style="ligoj-classic"] .sidebar .v-icon,
+[data-style="ligoj-classic"] .sidebar .nav-item {
+  color: #fff !important;
+}
+/* Nav item states must stay legible on the indigo rail. */
+[data-style="ligoj-classic"] .sidebar .nav-item:hover {
+  background: rgba(255, 255, 255, .14) !important;
+}
+[data-style="ligoj-classic"] .sidebar .nav-item.active {
+  background: #5363bd !important;
+  color: #fff !important;
+}
+
+/* Honour the OS-level reduced-motion preference: cut this theme's ripple and
+ * dialog animations when the user asks for less motion, like the md3 block. */
+@media (prefers-reduced-motion: reduce) {
+  [data-style="ligoj-classic"] .v-overlay__content > .v-card { animation: none; }
+  [data-style="ligoj-classic"] .v-ripple__animation--in,
+  [data-style="ligoj-classic"] .v-ripple__animation--out,
+  [data-style="ligoj-classic"] .lj-btn::after,
+  [data-style="ligoj-classic"] .lj-iconbtn::after,
+  [data-style="ligoj-classic"] .nav-item::after,
+  [data-style="ligoj-classic"] .sub-item::after {
+    transition: none !important;
+  }
+  [data-style="ligoj-classic"] .lj-btn:active::after,
+  [data-style="ligoj-classic"] .lj-iconbtn:active::after,
+  [data-style="ligoj-classic"] .nav-item:active::after,
+  [data-style="ligoj-classic"] .sub-item:active::after {
+    opacity: 0;
+  }
+}

--- a/app-ui/src/main/webapp/src/plugins/presets.js
+++ b/app-ui/src/main/webapp/src/plugins/presets.js
@@ -28,8 +28,8 @@ export const PRESET_OPTIONS = [
   /* --- classic / faithful --- */
   {
     id: 'ligoj-classic',
-    label: 'Ligoj Classic',
-    description: 'The original Ligoj light look — indigo + amber.',
+    label: 'Ligoj',
+    description: 'The default Ligoj light look — indigo + amber.',
     theme: 'ligojLight',
     style: 'default',
     dark: false,
@@ -43,6 +43,15 @@ export const PRESET_OPTIONS = [
     style: 'default',
     dark: true,
     swatch: ['#5c6bc0', '#ffb74d', '#121212'],
+  },
+  {
+    id: 'reforged',
+    label: 'Reforged',
+    description: 'Reforged Ligoj — faithful Bootstrap+Material palette, flat indigo rail.',
+    theme: 'ligojClassic',
+    style: 'ligoj-classic',
+    dark: false,
+    swatch: ['#3f51b5', '#9c27b0', '#0aa89e'],
   },
   {
     id: 'vscode-dark',

--- a/app-ui/src/main/webapp/src/plugins/styles.js
+++ b/app-ui/src/main/webapp/src/plugins/styles.js
@@ -34,6 +34,13 @@ export const STYLE_OPTIONS = [
     radius: '4px',
   },
   {
+    id: 'ligoj-classic',
+    label: 'Reforged',
+    description: 'Bootstrap Material revival — purple primary, teal accents, ripples, modal scale-in.',
+    previews: ['#9c27b0', '#0aa89e', '#3f51b5'],
+    radius: '4px',
+  },
+  {
     id: 'sharp',
     label: 'Sharp / Brutalist',
     description: 'Zero radius, monospaced labels, harsh borders.',

--- a/app-ui/src/main/webapp/src/plugins/vuetify.js
+++ b/app-ui/src/main/webapp/src/plugins/vuetify.js
@@ -212,9 +212,29 @@ const md3Dark = {
   },
 }
 
+// Ligoj Classic — faithful revival of the legacy Bootstrap + Material Design
+// skin (themes/bootstrap-material-design): purple primary, teal accents,
+// indigo toolbar. Paired with the `ligoj-classic` shape style in `styles.js`
+// (ripples + modal scale-in).
+const ligojClassic = {
+  dark: false,
+  colors: {
+    primary: '#9c27b0',
+    secondary: '#0aa89e',
+    accent: '#3f51b5',
+    error: '#f44336',
+    warning: '#ff9800',
+    info: '#039588',
+    success: '#4cae51',
+    background: '#fafafa',
+    surface: '#ffffff',
+  },
+}
+
 const themes = {
   ligojLight,
   ligojDark,
+  ligojClassic,
   solarizedLight,
   solarizedDark,
   githubLight,
@@ -233,6 +253,7 @@ const themes = {
 export const THEME_OPTIONS = [
   { id: 'ligojLight',      label: 'Ligoj Light',      dark: false, swatch: ['#1a237e', '#f57c00', '#fafafa'] },
   { id: 'ligojDark',       label: 'Ligoj Dark',       dark: true,  swatch: ['#5c6bc0', '#ffb74d', '#121212'] },
+  { id: 'ligojClassic',    label: 'Reforged',         dark: false, swatch: ['#9c27b0', '#0aa89e', '#3f51b5'] },
   { id: 'solarizedLight',  label: 'Solarized Light',  dark: false, swatch: ['#268bd2', '#b58900', '#fdf6e3'] },
   { id: 'solarizedDark',   label: 'Solarized Dark',   dark: true,  swatch: ['#268bd2', '#b58900', '#002b36'] },
   { id: 'githubLight',     label: 'GitHub Light',     dark: false, swatch: ['#0969da', '#1a7f37', '#ffffff'] },
@@ -279,6 +300,7 @@ function detectTheme() {
  */
 const PRESET_TO_THEME = {
   'ligoj-classic':    'ligojLight',
+  'reforged':         'ligojClassic',
   'ligoj-dark':       'ligojDark',
   'vscode-dark':      'vscodeDark',
   'solarized-press':  'solarizedLight',


### PR DESCRIPTION
## Context
Implements ligoj/plugin-ui#31 (revive the old Ligoj theme). Renames the former
"Ligoj Classic" preset to "Ligoj" (the default light look, unchanged), and adds a
new preset that faithfully revives the legacy Bootstrap+Material Design palette.

## Scope decisions
- Naming: the new preset is "Reforged", not "Ligoj classic" as literally worded in
  the issue. Rationale: its palette is purple/violet, so "classic" read as
  misleading next to the actual old light look; it sits after "Ligoj Dark" since
  users pick the base or the dark theme first. The legacy COLORS from the issue are
  kept exactly. Happy to rename if you prefer the literal "Ligoj classic".
- Toolbar color: the issue asks for toolbar #3f51b5 and selected #5363bd. The new
  VueJS shell has no Vuetify v-app-bar (the chrome is a custom side rail + a light
  top header). Applied #3f51b5 / #5363bd to the SIDE RAIL and flattened it to a
  solid fill — the per-`--primary` gradient turned the rail a harsh violet. The top
  header stays light, giving the clean "indigo chrome + white content" feel of the
  old theme.

## Changes
- vuetify.js — new `ligojClassic` theme (exact legacy colors: primary #9c27b0,
  info #039588, success #4cae51, etc.) + THEME_OPTIONS + PRESET_TO_THEME row.
- styles.js — new `ligoj-classic` shape style (ripples + modal scale-in, radius 4px).
- presets.js — relabel old preset to "Ligoj"; add the `reforged` preset.
- assets/vuetify-overrides.css — scoped `[data-style="ligoj-classic"]` block:
  flat indigo side rail (+ #5363bd active item, white text), teal chips (#0aa89e),
  teal checkbox/input underline (#039588), purple selected menus, ripple + dialog
  scale-in mirrored from the legacy ripples.css / modal.
- __tests__/plugins/presets.test.js — sync coverage for the new preset.

## Design rationale
Everything is scoped under the `data-style` attribute, so other presets are
untouched (verified: switching themes restores the default rail). The side-rail
recolor lives entirely in the override stylesheet — App.vue is not modified.

## What's not in this PR
- The colored KPI cards are the host's per-category semantic colors, left as is.
- No flattening of other host gradients beyond the Reforged side rail.

## Tests
npx vitest run (188 tests) and npm run build both pass. Runtime verified in the
browser (flat indigo rail, white text, #5363bd active item, purple accents, teal
chips/inputs, modal scale-in; non-regression of the default "Ligoj").

## Note
Base is feature/vuejs, so the issue won't auto-close. Refs ligoj/plugin-ui#31 —
to close manually after merge.

Feedback welcome — single isolated commit, easy to revert.