### PR TITLE
fix(nav): scroll the side menu when entries overflow the viewport

### DIFF
--- a/app-ui/src/main/webapp/src/App.vue
+++ b/app-ui/src/main/webapp/src/App.vue
@@ -491,6 +491,12 @@ body {
 .nav {
   padding: 10px;
   flex: 1;
+  /* min-height:0 lets this flex child shrink below its content height so it can
+     scroll instead of pushing .sb-foot off-screen on short viewports. */
+  min-height: 0;
+  overflow-y: auto;
+  scrollbar-width: thin;
+  scrollbar-color: rgba(255, 255, 255, .35) transparent;
 }
 
 .nav-item {


### PR DESCRIPTION
## Context
Implements ligoj/plugin-ui#35. With many nav entries on a short viewport, the
bottom of the left side menu overflowed and became unreachable.

## Changes
- App.vue, `.nav` rule: `overflow-y: auto` + `min-height: 0` (required so the
  flex child can shrink and scroll inside the column), plus a thin scrollbar
  (`scrollbar-width: thin`, translucent thumb that reads on the colored rail).
- No JS/logic change.

## Note
The pinned footer is `.sb-foot` ("About" + version), which sits outside `.nav`
and stays visible while the menu scrolls. (The "Profil" entry lives in the top
bar, not the side menu.)

## Tests
npx vitest run (186 tests) and npm run build pass. Verified in the authenticated
app: short viewport -> the side menu scrolls, all entries reachable, "About"
pinned at the bottom (checked under the Reforged theme too).

## Note
Base is feature/vuejs, so the issue won't auto-close. Refs ligoj/plugin-ui#35 —
to close manually after merge.

Feedback welcome — single isolated commit, trivial to revert.