### PR TITLE
feat(about): add a bug-report dialog with a prefilled issue template

### DIFF
--- a/app-ui/src/main/webapp/src/App.vue
+++ b/app-ui/src/main/webapp/src/App.vue
@@ -64,6 +64,7 @@
       </nav>
       <button v-if="app.refresh" class="icon-btn refresh-btn" :class="{ spin: refreshing }" title="Rafraîchir" @click="onRefresh"><v-icon>mdi-refresh</v-icon></button>
       <span class="sp" />
+      <button class="icon-btn" :title="i18n.t('about.reportBug')" @click="bugDialog = true"><v-icon>mdi-bug-outline</v-icon></button>
       <button class="user" :class="{ admin: auth.isAdmin }" @click="go('/profile')"><v-icon size="small" :color="auth.isAdmin ? 'secondary' : undefined">{{ auth.isAdmin ? 'mdi-shield-account' :
           'mdi-account' }}</v-icon>{{ auth.userName || 'invité' }}<v-tooltip v-if="auth.isAdmin" activator="parent" location="bottom" :text="i18n.t('profile.adminTooltip')" /></button>
       <button class="icon-btn" title="Se déconnecter" @click="logout"><v-icon>mdi-logout</v-icon></button>
@@ -74,6 +75,7 @@
     <div class="toast" :class="{ show: toastMsg }">{{ toastMsg }}</div>
     <ErrorSnackbar />
     <LoginPromptDialog />
+    <BugReportDialog v-model="bugDialog" />
   </div>
 </template>
 
@@ -88,6 +90,7 @@ import registry from '@/plugins/registry.js'
 import ErrorSnackbar from '@/components/ErrorSnackbar.vue'
 import LoginPromptDialog from '@/components/LoginPromptDialog.vue'
 import LigojIcon from '@/components/LigojIcon.vue'
+import BugReportDialog from '@/components/BugReportDialog.vue'
 
 const route = useRoute()
 const router = useRouter()
@@ -222,6 +225,7 @@ const NAV = computed(() => {
 })
 
 const collapsed = ref(false)
+const bugDialog = ref(false)
 const title = computed(() => {
   if (route.path === '/profile') return 'Profil'
   if (route.path.startsWith('/id/group')) return 'Groupes'

--- a/app-ui/src/main/webapp/src/__tests__/components/BugReportDialog.test.js
+++ b/app-ui/src/main/webapp/src/__tests__/components/BugReportDialog.test.js
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { mount } from '@vue/test-utils'
+import { createPinia, setActivePinia } from 'pinia'
+import { createVuetify } from 'vuetify'
+import * as components from 'vuetify/components'
+import * as directives from 'vuetify/directives'
+import { nextTick } from 'vue'
+import BugReportDialog from '@/components/BugReportDialog.vue'
+import { useAuthStore } from '@/stores/auth.js'
+
+const vuetify = createVuetify({ components, directives })
+
+let wrapper
+
+// v-dialog teleports its content to <body>, so assertions go through
+// `document`, not `wrapper.find`. Each test mounts a single dialog and tears
+// it down in afterEach to keep the teleported markup from leaking across tests.
+async function openDialog() {
+  wrapper = mount(BugReportDialog, {
+    attachTo: document.body,
+    props: { modelValue: true },
+    global: { plugins: [vuetify] },
+  })
+  await nextTick()
+  await nextTick()
+  return wrapper
+}
+
+const template = () => document.querySelector('.bug-template')?.value ?? ''
+
+function seedSession(applicationSettings) {
+  const auth = useAuthStore()
+  auth.session = {
+    userName: 'tester',
+    roles: ['USER'],
+    uiAuthorizations: ['.*'],
+    apiAuthorizations: [],
+    applicationSettings: applicationSettings ?? {
+      buildVersion: '4.0.2-test',
+      plugins: ['service:id:ldap', 'service:prov:aws'],
+    },
+  }
+}
+
+describe('<BugReportDialog>', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    window.location.hash = '#/about'
+  })
+
+  afterEach(() => {
+    wrapper?.unmount()
+    wrapper = undefined
+    document.body.innerHTML = ''
+    delete navigator.clipboard
+  })
+
+  it('builds a template containing the version, the URL and the plugins', async () => {
+    seedSession()
+    await openDialog()
+
+    const text = template()
+    expect(text).toContain('4.0.2-test')
+    expect(text).toContain('#/about')
+    expect(text).toContain('service:id:ldap')
+    expect(text).toContain('service:prov:aws')
+    expect(text).toContain('## Description')
+    expect(text).toContain('## Context')
+  })
+
+  it('uses the path when there is no hash, and never leaks a domain', async () => {
+    seedSession()
+    window.location.hash = ''
+    await openDialog()
+
+    const text = template()
+    // jsdom default pathname is "/"; no protocol/host should appear.
+    expect(text).not.toContain('http')
+    expect(text).not.toContain('localhost')
+  })
+
+  it('copies the template to the clipboard via the Clipboard API', async () => {
+    seedSession()
+    const writeText = vi.fn().mockResolvedValue()
+    Object.defineProperty(navigator, 'clipboard', { configurable: true, value: { writeText } })
+    await openDialog()
+
+    document.querySelector('.bug-btn.primary').click()
+    await nextTick()
+
+    expect(writeText).toHaveBeenCalledTimes(1)
+    const copied = writeText.mock.calls[0][0]
+    expect(copied).toContain('4.0.2-test')
+    expect(copied).toContain('service:id:ldap')
+  })
+
+  it('falls back gracefully when the Clipboard API is unavailable', async () => {
+    seedSession()
+    delete navigator.clipboard
+    document.execCommand = vi.fn().mockReturnValue(true)
+    await openDialog()
+
+    // Should not throw, and should fall back to execCommand('copy').
+    document.querySelector('.bug-btn.primary').click()
+    await nextTick()
+    expect(document.execCommand).toHaveBeenCalledWith('copy')
+  })
+
+  it('links to the Ligoj GitHub issue form in a new tab', async () => {
+    seedSession()
+    await openDialog()
+
+    const link = document.querySelector('.bug-foot a.bug-btn')
+    expect(link.getAttribute('href')).toContain('https://github.com/ligoj/ligoj/issues/new')
+    expect(link.getAttribute('target')).toBe('_blank')
+    expect(link.getAttribute('rel')).toContain('noopener')
+  })
+
+  it('shows a no-plugin placeholder when none are installed', async () => {
+    seedSession({ buildVersion: '1.0', plugins: [] })
+    await openDialog()
+
+    const text = template()
+    expect(text).toContain('1.0')
+    expect(text).toContain('Installed plugins')
+    expect(text).toContain('(none)')
+  })
+})

--- a/app-ui/src/main/webapp/src/components/BugReportDialog.vue
+++ b/app-ui/src/main/webapp/src/components/BugReportDialog.vue
@@ -1,0 +1,221 @@
+<!--
+  BugReportDialog — front-only "report a bug" helper. Builds a copy/paste
+  Markdown template pre-filled with the build version, the current in-app URL
+  (path only, no domain) and the installed plugins (all read from the session
+  via auth.appSettings — no backend call), then links to the GitHub issue form.
+
+  Chrome mirrors AboutView's License dialog (.lic look): the root re-declares
+  its design tokens locally because v-dialog teleports the card to <body>,
+  where scoped page vars don't reach.
+-->
+<template>
+  <v-dialog :model-value="modelValue" max-width="680" scrollable @update:model-value="emit('update:modelValue', $event)">
+    <div class="bug" :style="{ '--c': '#e0567a' }">
+      <header class="bug-head">
+        <span class="bug-orb"><v-icon size="20">mdi-bug-outline</v-icon></span>
+        <div class="bug-htxt">
+          <h3>{{ t('bugReport.title') }}</h3>
+          <p>{{ t('bugReport.hint') }}</p>
+        </div>
+        <button class="bug-x" :aria-label="t('common.close')" @click="close">
+          <v-icon size="20">mdi-close</v-icon>
+        </button>
+      </header>
+
+      <div class="bug-body">
+        <textarea ref="taRef" class="bug-template" readonly :value="template" @focus="selectAll" />
+      </div>
+
+      <footer class="bug-foot">
+        <a class="bug-btn" :href="issueUrl" target="_blank" rel="noopener noreferrer">
+          <v-icon size="16">mdi-github</v-icon>{{ t('bugReport.openIssue') }}
+          <v-icon size="14" class="bug-go">mdi-open-in-new</v-icon>
+        </a>
+        <span class="bug-sp" />
+        <button class="bug-btn primary" @click="copy">
+          <v-icon size="16">{{ copied ? 'mdi-check' : 'mdi-content-copy' }}</v-icon>
+          {{ copied ? t('bugReport.copied') : t('bugReport.copy') }}
+        </button>
+      </footer>
+    </div>
+  </v-dialog>
+</template>
+
+<script setup>
+import { computed, ref, watch } from 'vue'
+import { useAuthStore, useI18nStore } from '@ligoj/host'
+
+const props = defineProps({
+  modelValue: { type: Boolean, default: false },
+})
+const emit = defineEmits(['update:modelValue'])
+
+const auth = useAuthStore()
+const { t } = useI18nStore()
+
+const GITHUB_ISSUE_URL = 'https://github.com/ligoj/ligoj/issues/new'
+
+const version = computed(() => auth.appSettings?.buildVersion || t('bugReport.unknown'))
+
+// The in-app location WITHOUT the domain: prefer the hash route (this is a
+// hash-router SPA, e.g. "#/about"), else the pathname. Captured into a ref on
+// open so it reflects where the user actually was when they hit the button.
+const url = ref('')
+function captureUrl() {
+  if (typeof window === 'undefined') { url.value = ''; return }
+  url.value = window.location.hash || window.location.pathname || '/'
+}
+
+// appSettings.plugins is a list of backend keys (strings like
+// "service:id:ldap"). Stay robust to an object shape too (id/key/name), since
+// the exact form is backend-driven — fall back to JSON for anything exotic.
+const pluginLines = computed(() => {
+  const list = auth.appSettings?.plugins
+  if (!Array.isArray(list) || !list.length) return []
+  return list.map((p) => {
+    if (typeof p === 'string') return p
+    if (p && typeof p === 'object') return p.id || p.key || p.name || p.artifact || JSON.stringify(p)
+    return String(p)
+  })
+})
+
+const template = computed(() => {
+  const lines = [
+    `## ${t('bugReport.tplDescription')}`,
+    t('bugReport.tplDescPlaceholder'),
+    '',
+    `## ${t('bugReport.tplContext')}`,
+    `- ${t('bugReport.tplVersion')}: ${version.value}`,
+    `- ${t('bugReport.tplUrl')}: ${url.value}`,
+    `- ${t('bugReport.tplPlugins')}:`,
+  ]
+  const plugins = pluginLines.value
+  if (plugins.length) lines.push(...plugins.map((p) => `  - ${p}`))
+  else lines.push(`  - ${t('bugReport.tplNoPlugin')}`)
+  return lines.join('\n')
+})
+
+// Pre-fill the GitHub issue body so the user can submit directly; they can
+// still copy/paste from the textarea if they prefer.
+const issueUrl = computed(() => `${GITHUB_ISSUE_URL}?body=${encodeURIComponent(template.value)}`)
+
+const taRef = ref(null)
+const copied = ref(false)
+let copiedT
+
+function selectAll() {
+  taRef.value?.select?.()
+}
+
+async function copy() {
+  const text = template.value
+  try {
+    if (navigator.clipboard?.writeText) {
+      await navigator.clipboard.writeText(text)
+    } else {
+      throw new Error('clipboard API unavailable')
+    }
+  } catch {
+    // Fallback: select the textarea and let the legacy execCommand copy it,
+    // leaving the selection visible so the user can Ctrl/Cmd+C manually if
+    // even that is blocked.
+    const ta = taRef.value
+    if (ta) {
+      ta.focus()
+      ta.select()
+      try { document.execCommand('copy') } catch { /* user can copy manually */ }
+    }
+  }
+  copied.value = true
+  clearTimeout(copiedT)
+  copiedT = setTimeout(() => { copied.value = false }, 2000)
+}
+
+function close() { emit('update:modelValue', false) }
+
+// Refresh the captured URL each time the dialog opens.
+watch(() => props.modelValue, (open) => {
+  if (open) {
+    captureUrl()
+    copied.value = false
+  }
+}, { immediate: true })
+</script>
+
+<style scoped>
+.bug {
+  --surface: rgb(var(--v-theme-surface));
+  --card: rgb(var(--v-theme-surface));
+  --ink: rgb(var(--v-theme-on-surface));
+  --ink-3: rgba(var(--v-theme-on-surface), .55);
+  --border: rgba(var(--v-theme-on-surface), .12);
+  --hover: rgba(var(--v-theme-on-surface), .06);
+  --font: var(--lj-font, var(--v26-font, "Bricolage Grotesque", system-ui, sans-serif));
+  --mono: var(--lj-mono, var(--v26-mono, "JetBrains Mono", ui-monospace, monospace));
+  --radius: var(--lj-radius, 18px);
+  --radius-sm: var(--lj-radius-sm, 12px);
+  --shadow-lg: var(--lj-shadow-lg, 0 32px 64px -24px color-mix(in srgb, var(--c) 45%, transparent));
+  --border-w: var(--lj-border-width, 1px);
+  --border-c: var(--lj-border-color, var(--border));
+  --bold: var(--lj-weight-bold, 800);
+  color: var(--ink);
+  display: flex;
+  flex-direction: column;
+  max-height: 82vh;
+  border: var(--border-w) var(--lj-border-style, solid) var(--border-c);
+  border-radius: var(--radius);
+  background: linear-gradient(135deg, color-mix(in srgb, var(--c) 6%, var(--card)), var(--card));
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
+}
+
+.bug-head { display: flex; align-items: center; gap: 12px; padding: 16px 18px; border-bottom: 1px solid var(--border); }
+.bug-orb { width: 40px; height: 40px; border-radius: var(--radius-sm); flex: none; display: grid; place-items: center; color: #fff; background: linear-gradient(135deg, var(--c), color-mix(in srgb, var(--c) 70%, #000)); box-shadow: 0 8px 18px -8px color-mix(in srgb, var(--c) 65%, transparent); }
+.bug-htxt { display: flex; flex-direction: column; min-width: 0; flex: 1; }
+.bug-htxt h3 { font-family: var(--font); font-weight: var(--bold); font-size: 17px; margin: 0; letter-spacing: -.02em; }
+.bug-htxt p { margin: 1px 0 0; font-size: 12px; color: var(--ink-3); font-weight: 600; }
+.bug-x { display: grid; place-items: center; width: 34px; height: 34px; flex: none; border: 0; border-radius: var(--lj-radius-sm, 10px); background: transparent; color: var(--ink-3); cursor: pointer; transition: background .14s, color .14s; }
+.bug-x:hover { background: var(--hover); color: var(--ink); }
+
+.bug-body { padding: 16px 18px; overflow-y: auto; }
+.bug-template {
+  width: 100%;
+  min-height: 220px;
+  resize: vertical;
+  box-sizing: border-box;
+  font-family: var(--mono);
+  font-size: 12.5px;
+  line-height: 1.55;
+  color: var(--ink);
+  background: rgba(var(--v-theme-on-surface), .04);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 12px 14px;
+  white-space: pre;
+  overflow: auto;
+}
+.bug-template:focus { outline: 2px solid color-mix(in srgb, var(--c) 55%, transparent); outline-offset: 1px; }
+
+.bug-foot { display: flex; align-items: center; gap: 10px; padding: 12px 18px; border-top: 1px solid var(--border); }
+.bug-sp { flex: 1; }
+.bug-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-family: var(--font);
+  font-weight: 700;
+  font-size: 13px;
+  color: var(--ink);
+  text-decoration: none;
+  padding: 8px 16px;
+  border: var(--border-w) var(--lj-border-style, solid) var(--border-c);
+  border-radius: var(--lj-radius-sm, 10px);
+  background: transparent;
+  cursor: pointer;
+  transition: background .14s, border-color .14s;
+}
+.bug-btn:hover { background: var(--hover); border-color: color-mix(in srgb, var(--c) 35%, var(--border)); }
+.bug-btn.primary { color: #fff; border-color: transparent; background: linear-gradient(135deg, var(--c), color-mix(in srgb, var(--c) 70%, #000)); }
+.bug-btn.primary:hover { filter: brightness(1.05); }
+.bug-go { opacity: .7; }
+</style>

--- a/app-ui/src/main/webapp/src/i18n/en.js
+++ b/app-ui/src/main/webapp/src/i18n/en.js
@@ -221,6 +221,23 @@ export default {
   'about.apiHint': 'Endpoints, examples, and live SwaggerUI',
   'about.apiTokens': 'API tokens',
   'about.apiTokensHint': 'Create or revoke keys for the REST API',
+  'about.reportBug': 'Report a bug',
+  'about.reportBugHint': 'Pre-filled template + GitHub issue form',
+
+  // Bug report dialog
+  'bugReport.title': 'Report a bug',
+  'bugReport.hint': 'Copy the template below into a new GitHub issue.',
+  'bugReport.copy': 'Copy',
+  'bugReport.copied': 'Copied!',
+  'bugReport.openIssue': 'Open a GitHub issue',
+  'bugReport.unknown': 'unknown',
+  'bugReport.tplDescription': 'Description',
+  'bugReport.tplDescPlaceholder': '(describe the problem here)',
+  'bugReport.tplContext': 'Context',
+  'bugReport.tplVersion': 'Version',
+  'bugReport.tplUrl': 'URL',
+  'bugReport.tplPlugins': 'Installed plugins',
+  'bugReport.tplNoPlugin': '(none)',
 
   // Login
   'login.title': 'Ligoj',

--- a/app-ui/src/main/webapp/src/i18n/fr.js
+++ b/app-ui/src/main/webapp/src/i18n/fr.js
@@ -221,6 +221,23 @@ export default {
   'about.apiHint': 'Points d\'accès, exemples et SwaggerUI en direct',
   'about.apiTokens': 'Jetons API',
   'about.apiTokensHint': 'Créer ou révoquer des clés pour l\'API REST',
+  'about.reportBug': 'Signaler un bug',
+  'about.reportBugHint': 'Modèle pré-rempli + formulaire d\'issue GitHub',
+
+  // Bug report dialog
+  'bugReport.title': 'Signaler un bug',
+  'bugReport.hint': 'Copiez le modèle ci-dessous dans une nouvelle issue GitHub.',
+  'bugReport.copy': 'Copier',
+  'bugReport.copied': 'Copié !',
+  'bugReport.openIssue': 'Ouvrir une issue GitHub',
+  'bugReport.unknown': 'inconnue',
+  'bugReport.tplDescription': 'Description',
+  'bugReport.tplDescPlaceholder': '(décrivez le problème ici)',
+  'bugReport.tplContext': 'Contexte',
+  'bugReport.tplVersion': 'Version',
+  'bugReport.tplUrl': 'URL',
+  'bugReport.tplPlugins': 'Plugins installés',
+  'bugReport.tplNoPlugin': '(aucun)',
 
   // Login
   'login.title': 'Ligoj',

--- a/app-ui/src/main/webapp/src/views/AboutView.vue
+++ b/app-ui/src/main/webapp/src/views/AboutView.vue
@@ -25,6 +25,11 @@
             <span class="lr-txt"><span class="lr-title">{{ t('about.license') }}</span><span class="lr-sub">MIT</span></span>
             <v-icon size="16" class="lr-go">mdi-chevron-right</v-icon>
           </a>
+          <a class="lrow" @click="bugDialog = true">
+            <v-icon size="20" class="lr-ic">mdi-bug-outline</v-icon>
+            <span class="lr-txt"><span class="lr-title">{{ t('about.reportBug') }}</span><span class="lr-sub">{{ t('about.reportBugHint') }}</span></span>
+            <v-icon size="16" class="lr-go">mdi-chevron-right</v-icon>
+          </a>
           <a class="lrow" href="https://www.kloudy.fr/" target="_blank" rel="noopener noreferrer">
             <v-icon size="20" class="lr-ic">mdi-hammer-wrench</v-icon>
             <span class="lr-txt">
@@ -79,6 +84,8 @@
         </footer>
       </div>
     </v-dialog>
+
+    <BugReportDialog v-model="bugDialog" />
   </div>
 </template>
 
@@ -86,6 +93,7 @@
 import { computed, onMounted, ref } from 'vue'
 import { useRouter } from 'vue-router'
 import { useAppStore, useAuthStore, useI18nStore, LjPageHeader } from '@ligoj/host'
+import BugReportDialog from '@/components/BugReportDialog.vue'
 import brandColor from '@/assets/brand.png'
 
 const router = useRouter()
@@ -98,6 +106,7 @@ const appName = computed(() => auth.appSettings?.name || 'Ligoj')
 function go(path) { router.push(path) }
 
 const licenseDialog = ref(false)
+const bugDialog = ref(false)
 
 // Inlined MIT license text — kept here so the About view does not have
 // to fetch the LICENSE file from the backend (works offline / in dev).


### PR DESCRIPTION
## Context
Implements ligoj/plugin-ui#33. Adds a "report a bug" helper so users can open a
GitHub issue with the right context already filled in.

## What it does
- A reusable `BugReportDialog` shows a copy/paste Markdown template prefilled
  with: build version (`appSettings.buildVersion`), the current in-app URL
  (hash/path only, no domain), and the installed plugins (`appSettings.plugins`).
  All read from the session — no backend call.
- A "Copy" button (clipboard API + execCommand fallback) and an "Open a GitHub
  issue" link to `ligoj/ligoj/issues/new?body=<template>` (prefilled).

## Placement
Reachable from BOTH the top bar (bug icon) and the About page (Project card), per
the issue's "menu bar, About (maybe?)". Keep whichever you prefer — trivial to drop one.

## Tests
npx vitest run (192 tests, 6 new) and npm run build pass. Verified in the app:
template correct (version, domainless URL, real plugin keys), copy works, GitHub
link opens prefilled, readable in light and dark themes.

## Note
Base is feature/vuejs, so the issue won't auto-close. Refs ligoj/plugin-ui#33 —
to close manually after merge.

Feedback welcome — single isolated commit, easy to revert.