### PR TITLE
feat(monitoring): report browser errors to the user-log endpoint

### DIFF
--- a/app-api/src/main/resources/csv/system-authorization.csv
+++ b/app-api/src/main/resources/csv/system-authorization.csv
@@ -17,6 +17,7 @@ GET;^rest/node.*;API;USER
 GET;^rest/project.*;API;USER
 GET;^rest/subscription.*;API;USER
 GET;^webjars/.*;API;USER
+POST;^rest/user-log.*;API;USER
 
 ;.*;UI;ADMIN
 ;^api.*;UI;USER

--- a/app-ui/src/main/webapp/src/__tests__/plugins/errorReporter.test.js
+++ b/app-ui/src/main/webapp/src/__tests__/plugins/errorReporter.test.js
@@ -1,0 +1,68 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { reportError, __resetErrorReporterState } from '@/plugins/errorReporter.js'
+
+function okResponse() {
+  return { ok: true, status: 204, headers: { get: () => null } }
+}
+
+function lastPostBody() {
+  const call = globalThis.fetch.mock.calls.at(-1)
+  return JSON.parse(call[1].body)
+}
+
+describe('errorReporter', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    __resetErrorReporterState()
+    globalThis.fetch = vi.fn().mockResolvedValue(okResponse())
+    window.location.hash = ''
+  })
+
+  it('posts to rest/user-log, truncates the message to 2000 chars and sends a domain-less url', () => {
+    window.location.hash = '#/test'
+    reportError('x'.repeat(2500))
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+    const [url, opts] = globalThis.fetch.mock.calls[0]
+    expect(url).toBe('rest/user-log')
+    expect(opts.method).toBe('POST')
+
+    const body = JSON.parse(opts.body)
+    expect(body.message).toHaveLength(2000)
+    expect(body.url).toBe('#/test')
+    // No scheme / domain leaked into the reported url.
+    expect(body.url).not.toMatch(/^https?:\/\//)
+  })
+
+  it('coerces non-string messages and falls back to pathname when no hash', () => {
+    reportError(new Error('boom').message)
+    const body = lastPostBody()
+    expect(body.message).toBe('boom')
+    expect(body.url).toBe('/')
+  })
+
+  it('deduplicates an identical message sent repeatedly within the window', () => {
+    reportError('same error')
+    reportError('same error')
+    reportError('same error')
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+  })
+
+  it('still sends distinct messages', () => {
+    reportError('error A')
+    reportError('error B')
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(2)
+  })
+
+  it('is fire-and-forget: does not throw when the API call rejects', async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error('network down'))
+
+    expect(() => reportError('will fail to send')).not.toThrow()
+    // Let the rejected post settle; the internal .catch must swallow it.
+    await Promise.resolve()
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1)
+  })
+})

--- a/app-ui/src/main/webapp/src/main.js
+++ b/app-ui/src/main/webapp/src/main.js
@@ -8,6 +8,7 @@ import { loadAllPlugins } from './plugins/loader.js'
 import { registerBuiltinPlugins } from './plugins/index.js'
 import { bootCompact, bootReduceMotion } from './plugins/styles.js'
 import { bootPreset } from './plugins/presets.js'
+import { installErrorReporter } from './plugins/errorReporter.js'
 
 // Apply the persisted theme preset (color palette + shape style) and
 // the orthogonal compact toggle BEFORE the SPA mounts so the first
@@ -21,6 +22,10 @@ bootReduceMotion()
 
 const app = createApp(App)
 const pinia = createPinia()
+
+// Capture browser JS errors and forward them to the backend as early as
+// possible, so failures during boot are reported too.
+installErrorReporter(app)
 
 app.use(pinia)
 setActivePinia(pinia)

--- a/app-ui/src/main/webapp/src/plugins/errorReporter.js
+++ b/app-ui/src/main/webapp/src/plugins/errorReporter.js
@@ -1,0 +1,113 @@
+import { useApi } from '@/composables/useApi.js'
+
+// Browser error reporter: forwards JS errors to the backend `/rest/user-log`
+// endpoint. It is intentionally defensive — a failing report must never
+// cascade into another error, spam the server, or loop back onto itself.
+
+const MAX_MESSAGE_LENGTH = 2000
+const DEDUP_WINDOW_MS = 10_000
+const THROTTLE_MAX = 10
+const THROTTLE_WINDOW_MS = 60_000
+
+// message -> timestamp (ms) of the last send, for de-duplication.
+const recentMessages = new Map()
+let throttleWindowStart = 0
+let throttleCount = 0
+// Anti-loop guard: true while a report is being dispatched, so an error
+// raised by the reporting path itself is not captured again.
+let reporting = false
+let apiClient = null
+
+function getApi() {
+  // Lazily resolved: `useApi()` needs an active Pinia, which is only
+  // guaranteed once the app has booted (well after module import).
+  if (!apiClient) {
+    apiClient = useApi()
+  }
+  return apiClient
+}
+
+/**
+ * Report a single browser error to the backend. Fire-and-forget: this never
+ * throws and never rejects to the caller.
+ *
+ * @param {*} message The error message (coerced to a string, capped at 2000 chars).
+ */
+export function reportError(message) {
+  if (reporting) {
+    return
+  }
+  reporting = true
+  try {
+    const text = String(message ?? '').slice(0, MAX_MESSAGE_LENGTH)
+    const now = Date.now()
+
+    // DEDUP: ignore an identical message already sent within the window.
+    const last = recentMessages.get(text)
+    if (last !== undefined && now - last < DEDUP_WINDOW_MS) {
+      return
+    }
+    // Prune stale entries so the map stays bounded.
+    for (const [key, ts] of recentMessages) {
+      if (now - ts >= DEDUP_WINDOW_MS) {
+        recentMessages.delete(key)
+      }
+    }
+
+    // THROTTLE: cap the number of sends per rolling minute.
+    if (now - throttleWindowStart >= THROTTLE_WINDOW_MS) {
+      throttleWindowStart = now
+      throttleCount = 0
+    }
+    if (throttleCount >= THROTTLE_MAX) {
+      return
+    }
+
+    recentMessages.set(text, now)
+    throttleCount++
+
+    const payload = {
+      message: text,
+      // Path only, no domain — the hash carries the SPA route.
+      url: window.location.hash || window.location.pathname || '/',
+    }
+
+    // FIRE-AND-FORGET: `silent` avoids the global error store reacting to a
+    // failed log POST (which would itself be a cascade source).
+    try {
+      getApi().post('rest/user-log', payload, { silent: true }).catch(() => {})
+    } catch {
+      // Swallow any synchronous failure (e.g. API client unavailable).
+    }
+  } catch {
+    // The reporter must never throw, whatever happens above.
+  } finally {
+    reporting = false
+  }
+}
+
+/**
+ * Install the global error hooks on the Vue app and the window.
+ *
+ * @param {import('vue').App} app The Vue application instance.
+ */
+export function installErrorReporter(app) {
+  app.config.errorHandler = (err) => {
+    reportError(err?.message || String(err))
+    // Keep the default dev behaviour: surface the error in the console.
+    console.error(err)
+  }
+  window.addEventListener('error', (e) => reportError(e?.error?.message || e?.message))
+  window.addEventListener('unhandledrejection', (e) => reportError(e?.reason?.message || String(e?.reason)))
+}
+
+/**
+ * Test-only helper: reset the internal dedup/throttle/anti-loop state.
+ */
+export function __resetErrorReporterState() {
+  recentMessages.clear()
+  throttleWindowStart = 0
+  throttleCount = 0
+  reporting = false
+  apiClient = null
+}


### PR DESCRIPTION
## Context
Front-end capture part of ligoj/plugin-ui#34. Browser JS errors are now forwarded
to the `POST /rest/user-log` endpoint (added in ligoj/ligoj-api#23). The admin
"User logs" UI is a separate plugin-ui PR.

## What it does
- `plugins/errorReporter.js`: `reportError(message)` + `installErrorReporter(app)`.
  Captures errors via three standard hooks: `app.config.errorHandler`,
  `window 'error'` and `window 'unhandledrejection'`, and POSTs `{ message, url }`
  (url = in-app hash, no domain).
- `main.js`: wires it right after `createApp`.

## Design decisions (and why)
- Three standard hooks rather than proxying `console.error`: more reliable and far
  less noisy (console.error is used for intentional logging by many libs). The
  proxy option the issue floated stays open if you'd rather have it.
- Defensive by construction: dedup (same message within 10s ignored), throttle
  (max 10/min), fire-and-forget (`{ silent: true }` + `.catch`), and an anti-loop
  guard so an error raised by the reporting path itself is not re-captured.
- Message truncated to 2000 chars, url path-only — consistent with the backend.

## Authorization
- `GET /rest/user-log` stays admin-only (RBAC default-deny + `@PreAuthorize` on the
  resource).
- `POST` must be open to any authenticated user. That requires the added line in
  `app-api/.../system-authorization.csv`: `POST;^rest/user-log.*;API;USER`.
  Note: this CSV is seeded into `S_AUTHORIZATION` at plugin install / version bump
  (not on a plain restart), so the USER rule activates through the release process.
  Admin works immediately (role `.*`).

## Dependency
Needs the backend endpoint from ligoj/ligoj-api#23 (and its release). Until then the
POST simply 404s and is swallowed (fire-and-forget) — no user impact.

## What's not in this PR
The admin "User logs" view (table, date-range filter) — separate plugin-ui PR.

## Tests
`npx vitest run` (incl. errorReporter tests: truncation, domainless url, dedup,
fire-and-forget) and `npm run build` pass. Verified end-to-end locally: triggering
errors created rows in `ligoj_user_log` (dedup confirmed).

Feedback welcome — happy to adjust hooks, dedup window or throttle.