### PR TITLE
feat(about): move the bug-report trigger to the sidebar footer

### DIFF
--- a/app-ui/src/main/webapp/src/App.vue
+++ b/app-ui/src/main/webapp/src/App.vue
@@ -43,6 +43,7 @@
       <div class="sb-foot">
         <button class="ver" :class="{ active: route.path === '/about' }" @click="go('/about')"><v-icon size="14">mdi-information-outline</v-icon><span>{{ i18n.t('nav.about') }}</span><span
             v-if="appVersion" class="ver-num">{{ appVersion }}</span></button>
+        <button class="foot-bug" :aria-label="i18n.t('about.reportBug')" @click="bugDialog = true"><v-icon size="20">mdi-bug-outline</v-icon><v-tooltip activator="parent" location="top" :text="i18n.t('about.reportBug')" /></button>
       </div>
     </aside>
 
@@ -64,7 +65,6 @@
       </nav>
       <button v-if="app.refresh" class="icon-btn refresh-btn" :class="{ spin: refreshing }" title="Rafraîchir" @click="onRefresh"><v-icon>mdi-refresh</v-icon></button>
       <span class="sp" />
-      <button class="icon-btn" :title="i18n.t('about.reportBug')" @click="bugDialog = true"><v-icon>mdi-bug-outline</v-icon></button>
       <button class="user" :class="{ admin: auth.isAdmin }" @click="go('/profile')"><v-icon size="small" :color="auth.isAdmin ? 'secondary' : undefined">{{ auth.isAdmin ? 'mdi-shield-account' :
           'mdi-account' }}</v-icon>{{ auth.userName || 'invité' }}<v-tooltip v-if="auth.isAdmin" activator="parent" location="bottom" :text="i18n.t('profile.adminTooltip')" /></button>
       <button class="icon-btn" title="Se déconnecter" @click="logout"><v-icon>mdi-logout</v-icon></button>
@@ -625,13 +625,39 @@ body {
 
 .sb-foot {
   padding: 10px;
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+
+/* Bug-report trigger, sitting to the right of the version number next to the
+   About item (moved here from the top bar). Tinted orange so it stays visible
+   against the dark sidebar. */
+.foot-bug {
+  flex: none;
+  display: grid;
+  place-items: center;
+  width: 36px;
+  height: 36px;
+  border: 0;
+  background: transparent;
+  color: #ff8c42;
+  cursor: pointer;
+  border-radius: 8px;
+  transition: color .15s, background .15s;
+}
+
+.foot-bug:hover {
+  color: #ffa45c;
+  background: rgba(255, 140, 66, .15);
 }
 
 .ver {
   display: flex;
   align-items: center;
   gap: 7px;
-  width: 100%;
+  flex: 1;
+  min-width: 0;
   text-align: left;
   font-family: var(--v26-font);
   font-weight: 600;

--- a/app-ui/src/main/webapp/src/App.vue
+++ b/app-ui/src/main/webapp/src/App.vue
@@ -43,7 +43,7 @@
       <div class="sb-foot">
         <button class="ver" :class="{ active: route.path === '/about' }" @click="go('/about')"><v-icon size="14">mdi-information-outline</v-icon><span>{{ i18n.t('nav.about') }}</span><span
             v-if="appVersion" class="ver-num">{{ appVersion }}</span></button>
-        <button class="foot-bug" :aria-label="i18n.t('about.reportBug')" @click="bugDialog = true"><v-icon size="20">mdi-bug-outline</v-icon><v-tooltip activator="parent" location="top" :text="i18n.t('about.reportBug')" /></button>
+        <button class="foot-bug" :aria-label="i18n.t('about.reportBug')" @click="bugDialog = true"><v-icon size="18">mdi-bug-outline</v-icon><v-tooltip activator="parent" location="top" :text="i18n.t('about.reportBug')" /></button>
       </div>
     </aside>
 
@@ -624,21 +624,23 @@ body {
 }
 
 .sb-foot {
-  padding: 10px;
+  padding: 10px 8px;
   display: flex;
   align-items: center;
-  gap: 4px;
+  gap: 2px;
 }
 
 /* Bug-report trigger, sitting to the right of the version number next to the
    About item (moved here from the top bar). Tinted orange so it stays visible
-   against the dark sidebar. */
+   against every themed sidebar. `flex: none` keeps it from stealing room from
+   the version; the Reforged (`ligoj-classic`) theme's white-icon rule is
+   overridden in vuetify-overrides.css so the orange survives there too. */
 .foot-bug {
   flex: none;
   display: grid;
   place-items: center;
-  width: 36px;
-  height: 36px;
+  width: 30px;
+  height: 30px;
   border: 0;
   background: transparent;
   color: #ff8c42;
@@ -655,15 +657,19 @@ body {
 .ver {
   display: flex;
   align-items: center;
-  gap: 7px;
+  gap: 6px;
   flex: 1;
   min-width: 0;
+  /* Keep "About" + version on a single line: the wider mono fonts used by the
+     sharp / neon styles otherwise overflow the footer width and wrap to two
+     lines. */
+  white-space: nowrap;
   text-align: left;
   font-family: var(--v26-font);
   font-weight: 600;
   font-size: 13px;
   opacity: .7;
-  padding: 9px 12px;
+  padding: 9px 8px;
   border: 0;
   background: transparent;
   color: inherit;
@@ -682,9 +688,13 @@ body {
   background: rgba(255, 255, 255, .12);
 }
 
-/* App version — thin, dimmed, pushed to the right edge of the button. */
+/* App version — thin, dimmed, pushed to the right edge of the button. Shrinks
+   with an ellipsis as a last resort so it never forces a wrap. */
 .ver-num {
   margin-left: auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
   font-weight: 200;
   font-size: 11px;
   opacity: .7;

--- a/app-ui/src/main/webapp/src/assets/vuetify-overrides.css
+++ b/app-ui/src/main/webapp/src/assets/vuetify-overrides.css
@@ -1271,6 +1271,11 @@
 [data-style="ligoj-classic"] .sidebar .nav-item {
   color: #fff !important;
 }
+/* …except the footer bug-report trigger, which keeps its orange tint (the
+   white rule above would otherwise flatten it into the rest of the icons). */
+[data-style="ligoj-classic"] .sidebar .foot-bug .v-icon {
+  color: #ff8c42 !important;
+}
 /* Nav item states must stay legible on the indigo rail. */
 [data-style="ligoj-classic"] .sidebar .nav-item:hover {
   background: rgba(255, 255, 255, .14) !important;

--- a/app-ui/src/main/webapp/src/host.js
+++ b/app-ui/src/main/webapp/src/host.js
@@ -36,6 +36,9 @@ export { default as PluginFeatures } from './components/PluginFeatures.vue'
 export { default as VibrantDataTable } from './components/VibrantDataTable.vue'
 export { default as VibrantConfirmDialog } from './components/VibrantConfirmDialog.vue'
 export { default as LigojIcon } from './components/LigojIcon.vue'
+// Bug-report dialog (prefilled issue template) — exported so plugins can open
+// the same dialog the host shell mounts (e.g. the System Information page).
+export { default as BugReportDialog } from './components/BugReportDialog.vue'
 // 2026 chrome primitives, factored out of the per-view scoped CSS so every
 // plugin shares one styled implementation (and one source of truth for the
 // design tokens). Pair with the global `.lj-surface` utility class


### PR DESCRIPTION
## Context
Follow-up on ligoj/plugin-ui#33 review: the bug-report trigger moves from the top
toolbar to the sidebar footer, and BugReportDialog is exported so plugin-ui can
reuse it (for the Information page link, in a companion plugin-ui PR).

## Changes
- App.vue: removed the bug icon from the top bar; added it in the sidebar footer
  (`.sb-foot`) to the right of the version, with a Vuetify tooltip. The
  BugReportDialog stays mounted here. (Icon styled orange per request.)
- host.js: `export { default as BugReportDialog }` so plugin-ui can import it from
  @ligoj/host.

## Not in this PR
- The Information "Build" card link lives in plugin-ui (companion PR, depends on
  this export).
- AboutView's existing bug link is unchanged.

## Tests
npx vitest run (199) + npm run build pass. Verified: icon gone from the top bar,
present in the footer (opens the prefilled dialog).

Refs ligoj/plugin-ui#33.