### PR TITLE
feat(nav): add Hooks entry to the Administration menu

### DIFF
--- a/app-ui/src/main/webapp/src/App.vue
+++ b/app-ui/src/main/webapp/src/App.vue
@@ -156,6 +156,7 @@ const BASE_NAV = [
       { labelKey: 'nav.plugins', icon: 'mdi-puzzle', route: '/system/plugin', match: '/system/plugin', auth: 'system/plugin' },
       { labelKey: 'nav.nodes', icon: 'mdi-server-network', route: '/system/node', match: '/system/node', auth: 'system/node' },
       { labelKey: 'nav.configuration', icon: 'mdi-cog-outline', route: '/system/configuration', match: '/system/configuration', auth: 'system/configuration' },
+      { labelKey: 'nav.hooks', icon: 'mdi-webhook', route: '/system/hook', match: '/system/hook', auth: 'system/hook' },
       { labelKey: 'nav.roles', icon: 'mdi-shield-account', route: '/system/role', match: '/system/role', auth: 'system/role' },
       { labelKey: 'nav.systemUsers', icon: 'mdi-account-supervisor', route: '/system/user', match: '/system/user', auth: 'system/user' },
       { labelKey: 'nav.cache', icon: 'mdi-database-clock', route: '/system/cache', match: '/system/cache', auth: 'system/cache' },
@@ -259,6 +260,7 @@ const title = computed(() => {
   if (route.path.startsWith('/system/plugin')) return 'Plugins'
   if (route.path.startsWith('/system/node')) return 'Nœuds'
   if (route.path.startsWith('/system/configuration')) return 'Configuration'
+  if (route.path.startsWith('/system/hook')) return 'Hooks'
   if (route.path.startsWith('/system/role')) return 'Rôles'
   if (route.path.startsWith('/system/user')) return 'Utilisateurs système'
   if (route.path.startsWith('/system/cache')) return 'Cache'

--- a/app-ui/src/main/webapp/src/i18n/en.js
+++ b/app-ui/src/main/webapp/src/i18n/en.js
@@ -11,6 +11,7 @@ export default {
   'nav.system': 'Administration',
   'nav.information': 'Information',
   'nav.configuration': 'Configuration',
+  'nav.hooks': 'Hooks',
   'nav.roles': 'Roles',
   'nav.plugins': 'Plugins',
   'nav.nodes': 'Nodes',

--- a/app-ui/src/main/webapp/src/i18n/fr.js
+++ b/app-ui/src/main/webapp/src/i18n/fr.js
@@ -11,6 +11,7 @@ export default {
   'nav.system': 'Administration',
   'nav.information': 'Informations',
   'nav.configuration': 'Configuration',
+  'nav.hooks': 'Hooks',
   'nav.roles': 'Rôles',
   'nav.plugins': 'Plugins',
   'nav.nodes': 'Nœuds',


### PR DESCRIPTION
Companion to ligoj/plugin-ui#43. Adds the "Hooks" entry to the Administration sidebar (inline with the
other system screens, between Configuration and Roles; icon mdi-webhook, auth `system/hook`), the tab-title
mapping for /system/hook, and the `nav.hooks` i18n key (EN+FR).

The screen itself (route /system/hook) lives in plugin-ui — merge/deploy ligoj/plugin-ui#43 FIRST, otherwise
the menu entry points to a route that isn't registered yet.

Tests: vitest 223 + npm run build OK.
