### PR TITLE
feat(nav): add Tasks entry to the Administration menu

### DIFF
--- a/app-ui/src/main/webapp/src/App.vue
+++ b/app-ui/src/main/webapp/src/App.vue
@@ -160,6 +160,7 @@ const BASE_NAV = [
       { labelKey: 'nav.systemUsers', icon: 'mdi-account-supervisor', route: '/system/user', match: '/system/user', auth: 'system/user' },
       { labelKey: 'nav.cache', icon: 'mdi-database-clock', route: '/system/cache', match: '/system/cache', auth: 'system/cache' },
       { labelKey: 'nav.bench', icon: 'mdi-speedometer', route: '/system/bench', match: '/system/bench', auth: 'system/bench' },
+      { labelKey: 'nav.tasks', icon: 'mdi-timer-sand', route: '/system/task', match: '/system/task', auth: 'system/task' },
       { labelKey: 'nav.information', icon: 'mdi-information', route: '/system/information', match: '/system/information', auth: 'system' },
     ]
   },
@@ -263,6 +264,7 @@ const title = computed(() => {
   if (route.path.startsWith('/system/user')) return 'Utilisateurs système'
   if (route.path.startsWith('/system/cache')) return 'Cache'
   if (route.path.startsWith('/system/bench')) return 'Bench'
+  if (route.path.startsWith('/system/task')) return 'Tâches'
   if (route.path.startsWith('/system/information')) return 'Information'
   if (route.path.startsWith('/system')) return 'Administration'
   if (route.path.startsWith('/api/token')) return 'Jetons d\'API'

--- a/app-ui/src/main/webapp/src/i18n/en.js
+++ b/app-ui/src/main/webapp/src/i18n/en.js
@@ -16,6 +16,7 @@ export default {
   'nav.nodes': 'Nodes',
   'nav.cache': 'Cache',
   'nav.bench': 'Bench',
+  'nav.tasks': 'Tasks',
   'nav.systemUsers': 'System users',
   'nav.profile': 'Profile',
   'nav.about': 'About',

--- a/app-ui/src/main/webapp/src/i18n/fr.js
+++ b/app-ui/src/main/webapp/src/i18n/fr.js
@@ -16,6 +16,7 @@ export default {
   'nav.nodes': 'Nœuds',
   'nav.cache': 'Cache',
   'nav.bench': 'Bench',
+  'nav.tasks': 'Tâches',
   'nav.systemUsers': 'Utilisateurs système',
   'nav.profile': 'Profil',
   'nav.about': 'À propos',


### PR DESCRIPTION
Companion to ligoj/plugin-ui#44. Adds the "Tasks" entry to the Administration sidebar (inline, after Bench;
icon mdi-timer-sand, auth `system/task`), the tab-title mapping for /system/task, and the nav.tasks i18n key
(EN+FR). The screen lives in plugin-ui (route /system/task) — merge/deploy ligoj/plugin-ui#44 first.
Tests: vitest 223 + build OK.
